### PR TITLE
Feat: hide minowski dll in visual studio project view

### DIFF
--- a/src/DeepNestLib/DeepNestLib.nuspec
+++ b/src/DeepNestLib/DeepNestLib.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>DeepNest</id>
-		<version>1.0.6</version>
+		<version>1.0.7</version>
 		<title>DeepNestLib</title>
 		<authors>Rafael del Molino</authors>
 		<requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/MinkowskiWrapper/build/DeepNest.targets
+++ b/src/MinkowskiWrapper/build/DeepNest.targets
@@ -4,6 +4,7 @@
 		<None Include="@(NativeLibs)">
 			<Link>%(FileName)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Visible>false</Visible>
 		</None>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Super minor but this change means the dll doesn't show up in the project tree in visual studio.

![image](https://github.com/user-attachments/assets/eb09faeb-1c1f-496d-b794-b77feb2acc39)
