### PR TITLE
refactor: Cleanup deepnest background. Extract classes into separate files.

### DIFF
--- a/src/DeepNestLib/Background/ClipCacheItem.cs
+++ b/src/DeepNestLib/Background/ClipCacheItem.cs
@@ -1,0 +1,10 @@
+﻿using ClipperLib;
+
+namespace DeepNestLib.Background
+{
+    public class ClipCacheItem
+    {
+        public int index;
+        public IntPoint[][] Nfpp;
+    }
+}

--- a/src/DeepNestLib/Background/DbCache.cs
+++ b/src/DeepNestLib/Background/DbCache.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace DeepNestLib.Background
+{
+    public class DbCache(WindowUnk w)
+    {
+        public WindowUnk window = w;
+
+        public bool Has(DbCacheKey obj)
+        {
+            NfpCacheKey key = new NfpCacheKey(obj); // Create the new struct key
+            return window.nfpCache.ContainsKey(key);
+        }
+
+        internal void Insert(DbCacheKey obj, bool inner = false)
+        {
+            NfpCacheKey key = new NfpCacheKey(obj); // Create the new struct key
+            List<NFP> value = NestingService.CloneNfp(obj.nfp, inner).ToList();
+            window.nfpCache.TryAdd(key, value);
+        }
+
+        public NFP[] Find(DbCacheKey obj, bool inner = false)
+        {
+            NfpCacheKey key = new NfpCacheKey(obj); // Create the new struct key
+            if (window.nfpCache.TryGetValue(key, out List<NFP> cachedNfp))
+            {
+                return NestingService.CloneNfp(cachedNfp.ToArray(), inner);
+            }
+            return null;
+        }
+    }
+}

--- a/src/DeepNestLib/Background/WindowUnk.cs
+++ b/src/DeepNestLib/Background/WindowUnk.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace DeepNestLib.Background
+{
+    public class WindowUnk
+    {
+        public WindowUnk()
+        {
+            db = new DbCache(this);
+        }
+
+        public ConcurrentDictionary<NfpCacheKey, List<NFP>> nfpCache = new();
+        public DbCache db;
+    }
+}

--- a/src/DeepNestLib/DeepNestLib.csproj
+++ b/src/DeepNestLib/DeepNestLib.csproj
@@ -48,10 +48,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\clipper\clipper_library.csproj" >
+        <ProjectReference Include="..\clipper\clipper_library.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
-        <ProjectReference Include="..\MinkowskiWrapper\MinkowskiWrapper.csproj" >
+        <ProjectReference Include="..\MinkowskiWrapper\MinkowskiWrapper.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
     </ItemGroup>

--- a/src/DeepNestLib/NestingContext.cs
+++ b/src/DeepNestLib/NestingContext.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DeepNestLib.Background;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -31,11 +32,11 @@ namespace DeepNestLib
         {
             current = null;
             Nest = new SvgNest(_config);
-            Background.cacheProcess = new ConcurrentDictionary<string, NFP[]>();
-            Background.window = new windowUnk();
-            Background.callCounter = 0;
+            NestingService.cacheProcess = new ConcurrentDictionary<string, NFP[]>();
+            NestingService.window = new WindowUnk();
+            NestingService.callCounter = 0;
             Iterations = 0;
-            Background.UseParallel = _config.UseParallel;
+            NestingService.UseParallel = _config.UseParallel;
         }
 
         bool offsetTreePhase = true;
@@ -52,7 +53,7 @@ namespace DeepNestLib
             {
                 Sheets[i].id = i;
             }
-            foreach (var item in Polygons)
+            foreach (NFP item in Polygons)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 NFP clone = new NFP();
@@ -62,10 +63,10 @@ namespace DeepNestLib
                 if (item.children != null)
                 {
                     clone.children = new List<NFP>();
-                    foreach (var citem in item.children)
+                    foreach (NFP citem in item.children)
                     {
                         clone.children.Add(new NFP());
-                        var l = clone.children.Last();
+                        NFP l = clone.children.Last();
                         l.id = citem.id;
                         l.source = citem.source;
                         l.Points = citem.Points.Select(z => new SvgPoint(z.x, z.y) { exact = z.exact }).ToArray();
@@ -75,7 +76,7 @@ namespace DeepNestLib
             }
 
 
-            foreach (var item in Sheets)
+            foreach (NFP item in Sheets)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 NFP clone = new NFP();
@@ -85,11 +86,11 @@ namespace DeepNestLib
                 if (item.children != null)
                 {
                     clone.children = new List<NFP>();
-                    foreach (var citem in item.children)
+                    foreach (NFP citem in item.children)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         clone.children.Add(new NFP());
-                        var l = clone.children.Last();
+                        NFP l = clone.children.Last();
                         l.id = citem.id;
                         l.source = citem.source;
                         l.Points = citem.Points.Select(z => new SvgPoint(z.x, z.y) { exact = z.exact }).ToArray();
@@ -100,14 +101,14 @@ namespace DeepNestLib
 
             if (offsetTreePhase)
             {
-                var grps = lpoly.GroupBy(z => z.source).ToArray();
-                if (Background.UseParallel)
+                IGrouping<int?, NFP>[] grps = lpoly.GroupBy(z => z.source).ToArray();
+                if (NestingService.UseParallel)
                 {
                     Parallel.ForEach(grps, (item) =>
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         SvgNest.offsetTree(item.First(), 0.5 * SvgNest.Config.Spacing, SvgNest.Config, cancellationToken);
-                        foreach (var zitem in item)
+                        foreach (NFP? zitem in item)
                         {
                             cancellationToken.ThrowIfCancellationRequested();
                             zitem.Points = item.First().Points.ToArray();
@@ -119,11 +120,11 @@ namespace DeepNestLib
                 else
                 {
 
-                    foreach (var item in grps)
+                    foreach (IGrouping<int?, NFP>? item in grps)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         SvgNest.offsetTree(item.First(), 0.5 * SvgNest.Config.Spacing, SvgNest.Config, cancellationToken);
-                        foreach (var zitem in item)
+                        foreach (NFP? zitem in item)
                         {
                             cancellationToken.ThrowIfCancellationRequested();
                             zitem.Points = item.First().Points.ToArray();
@@ -131,7 +132,7 @@ namespace DeepNestLib
                     }
                 }
 
-                foreach (var item in lsheets)
+                foreach (NFP item in lsheets)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     SvgNest.offsetTree(item, SvgNest.Config.SheetEdgeOffset, SvgNest.Config, cancellationToken, true);
@@ -141,14 +142,14 @@ namespace DeepNestLib
 
 
             List<NestItem> partsLocal = new List<NestItem>();
-            var p1 = lpoly.GroupBy(z => z.source).Select(z => new NestItem()
+            IEnumerable<NestItem> p1 = lpoly.GroupBy(z => z.source).Select(z => new NestItem()
             {
                 Polygon = z.First(),
                 IsSheet = false,
                 Quanity = z.Count()
             });
 
-            var p2 = lsheets.GroupBy(z => z.source).Select(z => new NestItem()
+            IEnumerable<NestItem> p2 = lsheets.GroupBy(z => z.source).Select(z => new NestItem()
             {
                 Polygon = z.First(),
                 IsSheet = true,
@@ -159,14 +160,14 @@ namespace DeepNestLib
             partsLocal.AddRange(p1);
             partsLocal.AddRange(p2);
             int srcc = 0;
-            foreach (var item in partsLocal)
+            foreach (NestItem item in partsLocal)
             {
                 item.Polygon.source = srcc++;
             }
 
             cancellationToken.ThrowIfCancellationRequested();
             Nest.launchWorkers(partsLocal.ToArray(), cancellationToken);
-            var plcpr = Nest.nests.First();
+            SheetPlacement plcpr = Nest.nests.First();
 
             if (current == null || plcpr.fitness < current.fitness)
             {
@@ -189,33 +190,33 @@ namespace DeepNestLib
 
             PlacedPartsCount = 0;
             List<NFP> placed = new List<NFP>();
-            foreach (var item in Polygons)
+            foreach (NFP item in Polygons)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 item.sheet = null;
             }
             List<int> sheetsIds = new List<int>();
 
-            foreach (var item in plcpr.placements)
+            foreach (List<SheetPlacementItem> item in plcpr.placements)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                foreach (var zitem in item)
+                foreach (SheetPlacementItem zitem in item)
                 {
-                    var sheetid = zitem.sheetId;
+                    int sheetid = zitem.sheetId;
                     if (!sheetsIds.Contains(sheetid))
                     {
                         sheetsIds.Add(sheetid);
                     }
 
-                    var sheet = Sheets.First(z => z.id == sheetid);
+                    NFP sheet = Sheets.First(z => z.id == sheetid);
                     totalSheetsArea += GeometryUtil.polygonArea(sheet);
 
-                    foreach (var ssitem in zitem.sheetplacements)
+                    foreach (PlacementItem ssitem in zitem.sheetplacements)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
                         PlacedPartsCount++;
-                        var poly = Polygons.First(z => z.id == ssitem.id);
+                        NFP poly = Polygons.First(z => z.id == ssitem.id);
                         totalPartsArea += GeometryUtil.polygonArea(poly);
                         placed.Add(poly);
                         poly.sheet = sheet;
@@ -226,12 +227,12 @@ namespace DeepNestLib
                 }
             }
 
-            var emptySheets = Sheets.Where(z => !sheetsIds.Contains(z.id)).ToArray();
+            NFP[] emptySheets = Sheets.Where(z => !sheetsIds.Contains(z.id)).ToArray();
 
             MaterialUtilization = Math.Abs(totalPartsArea / totalSheetsArea);
 
-            var ppps = Polygons.Where(z => !placed.Contains(z));
-            foreach (var item in ppps)
+            IEnumerable<NFP> ppps = Polygons.Where(z => !placed.Contains(z));
+            foreach (NFP? item in ppps)
             {
                 item.x = -1000;
                 item.y = 0;
@@ -249,14 +250,14 @@ namespace DeepNestLib
                 Sheets[i].y = y;
                 if (Sheets[i] is Sheet)
                 {
-                    var r = Sheets[i] as Sheet;
+                    Sheet? r = Sheets[i] as Sheet;
                     x += r.Width + gap;
                 }
                 else
                 {
-                    var maxx = Sheets[i].Points.Max(z => z.x);
-                    var minx = Sheets[i].Points.Min(z => z.x);
-                    var w = maxx - minx;
+                    double maxx = Sheets[i].Points.Max(z => z.x);
+                    double minx = Sheets[i].Points.Min(z => z.x);
+                    double w = maxx - minx;
                     x += w + gap;
                 }
             }
@@ -264,7 +265,7 @@ namespace DeepNestLib
 
         public void AddSheet(int w, int h, int src)
         {
-            var tt = new RectangleSheet();
+            RectangleSheet tt = new RectangleSheet();
             tt.Name = "sheet" + (Sheets.Count + 1);
             Sheets.Add(tt);
 
@@ -298,12 +299,12 @@ namespace DeepNestLib
         }
         public void LoadInputData(string path, int count)
         {
-            var dir = new DirectoryInfo(path);
-            foreach (var item in dir.GetFiles("*.svg"))
+            DirectoryInfo dir = new DirectoryInfo(path);
+            foreach (FileInfo item in dir.GetFiles("*.svg"))
             {
                 try
                 {
-                    var src = GetNextSource();
+                    int src = GetNextSource();
                     for (int i = 0; i < count; i++)
                     {
                         ImportFromRawDetail(SvgParser.LoadSvg(item.FullName), src);
@@ -319,11 +320,11 @@ namespace DeepNestLib
         {
             NFP po = null;
             List<NFP> nfps = new List<NFP>();
-            foreach (var item in raw.Outers)
+            foreach (LocalContour item in raw.Outers)
             {
-                var nn = new NFP();
+                NFP nn = new NFP();
                 nfps.Add(nn);
-                foreach (var pitem in item.Points)
+                foreach (System.Drawing.PointF pitem in item.Points)
                 {
                     nn.AddPoint(new SvgPoint(pitem.X, pitem.Y));
                 }
@@ -331,13 +332,17 @@ namespace DeepNestLib
 
             if (nfps.Any())
             {
-                var tt = nfps.OrderByDescending(z => z.Area).First();
+                NFP tt = nfps.OrderByDescending(z => z.Area).First();
                 po = tt;
                 po.Name = raw.Name;
 
-                foreach (var r in nfps)
+                foreach (NFP r in nfps)
                 {
-                    if (r == tt) continue;
+                    if (r == tt)
+                    {
+                        continue;
+                    }
+
                     if (po.children == null)
                     {
                         po.children = new List<NFP>();
@@ -382,29 +387,29 @@ namespace DeepNestLib
         }
         public void LoadXml(string v)
         {
-            var d = XDocument.Load(v);
-            var f = d.Descendants().First();
-            var gap = int.Parse(f.Attribute("gap").Value);
+            XDocument d = XDocument.Load(v);
+            XElement f = d.Descendants().First();
+            int gap = int.Parse(f.Attribute("gap").Value);
             SvgNest.Config.Spacing = gap;
 
-            foreach (var item in d.Descendants("sheet"))
+            foreach (XElement item in d.Descendants("sheet"))
             {
                 int src = GetNextSheetSource();
-                var cnt = int.Parse(item.Attribute("count").Value);
-                var ww = int.Parse(item.Attribute("width").Value);
-                var hh = int.Parse(item.Attribute("height").Value);
+                int cnt = int.Parse(item.Attribute("count").Value);
+                int ww = int.Parse(item.Attribute("width").Value);
+                int hh = int.Parse(item.Attribute("height").Value);
 
                 for (int i = 0; i < cnt; i++)
                 {
                     AddSheet(ww, hh, src);
                 }
             }
-            foreach (var item in d.Descendants("part"))
+            foreach (XElement item in d.Descendants("part"))
             {
-                var cnt = int.Parse(item.Attribute("count").Value);
-                var path = item.Attribute("path").Value;
-                var r = SvgParser.LoadSvg(path);
-                var src = GetNextSource();
+                int cnt = int.Parse(item.Attribute("count").Value);
+                string path = item.Attribute("path").Value;
+                RawDetail r = SvgParser.LoadSvg(path);
+                int src = GetNextSource();
 
                 for (int i = 0; i < cnt; i++)
                 {

--- a/src/DeepNestLib/NestingService.cs
+++ b/src/DeepNestLib/NestingService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using ClipperLib;
+using DeepNestLib.Background;
+using Minkowski;
+using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -7,22 +10,20 @@ using System.Drawing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ClipperLib;
-using Minkowski;
 
 namespace DeepNestLib
 {
-    public class Background
+    public class NestingService
     {
 
         public static bool EnableCaches = true;
 
         public static bool UseParallel { get; set; }
 
-        public static NFP shiftPolygon(NFP p, PlacementItem shift)
+        public static NFP ShiftPolygon(NFP p, PlacementItem shift)
         {
             NFP shifted = new NFP();
-            for (var i = 0; i < p.length; i++)
+            for (int i = 0; i < p.length; i++)
             {
                 shifted.AddPoint(new SvgPoint(p[i].x + shift.x, p[i].y + shift.y) { exact = p[i].exact });
             }
@@ -31,7 +32,7 @@ namespace DeepNestLib
                 shifted.children = new List<NFP>();
                 for (int i = 0; i < p.children.Count; i++)
                 {
-                    shifted.children.Add(shiftPolygon(p.children[i], shift));
+                    shifted.children.Add(ShiftPolygon(p.children[i], shift));
                 }
             }
 
@@ -41,154 +42,8 @@ namespace DeepNestLib
 
         // returns the square of the length of any merged lines
         // filter out any lines less than minlength long
-        public static MergedResult mergedLength(NFP[] parts, NFP p, double minlength, double tolerance)
+        public static MergedResult MergedLength(NFP[] parts, NFP p, double minlength, double tolerance)
         {
-            //            var min2 = minlength * minlength;
-            //            var totalLength = 0;
-            //            var segments = [];
-
-            //            for (var i = 0; i < p.length; i++)
-            //            {
-            //                var A1 = p[i];
-
-            //                if (i + 1 == p.length)
-            //                {
-            //                    A2 = p[0];
-            //                }
-            //                else
-            //                {
-            //                    var A2 = p[i + 1];
-            //                }
-
-            //                if (!A1.exact || !A2.exact)
-            //                {
-            //                    continue;
-            //                }
-
-            //                var Ax2 = (A2.x - A1.x) * (A2.x - A1.x);
-            //                var Ay2 = (A2.y - A1.y) * (A2.y - A1.y);
-
-            //                if (Ax2 + Ay2 < min2)
-            //                {
-            //                    continue;
-            //                }
-
-            //                var angle = Math.atan2((A2.y - A1.y), (A2.x - A1.x));
-
-            //                var c = Math.cos(-angle);
-            //                var s = Math.sin(-angle);
-
-            //                var c2 = Math.cos(angle);
-            //                var s2 = Math.sin(angle);
-
-            //                var relA2 = { x: A2.x - A1.x, y: A2.y - A1.y};
-            //            var rotA2x = relA2.x * c - relA2.y * s;
-
-            //            for (var j = 0; j < parts.length; j++)
-            //            {
-            //                var B = parts[j];
-            //                if (B.length > 1)
-            //                {
-            //                    for (var k = 0; k < B.length; k++)
-            //                    {
-            //                        var B1 = B[k];
-
-            //                        if (k + 1 == B.length)
-            //                        {
-            //                            var B2 = B[0];
-            //                        }
-            //                        else
-            //                        {
-            //                            var B2 = B[k + 1];
-            //                        }
-
-            //                        if (!B1.exact || !B2.exact)
-            //                        {
-            //                            continue;
-            //                        }
-            //                        var Bx2 = (B2.x - B1.x) * (B2.x - B1.x);
-            //                        var By2 = (B2.y - B1.y) * (B2.y - B1.y);
-
-            //                        if (Bx2 + By2 < min2)
-            //                        {
-            //                            continue;
-            //                        }
-
-            //                        // B relative to A1 (our point of rotation)
-            //                        var relB1 = { x: B1.x - A1.x, y: B1.y - A1.y};
-            //                    var relB2 = { x: B2.x - A1.x, y: B2.y - A1.y};
-
-
-            //                // rotate such that A1 and A2 are horizontal
-            //                var rotB1 = { x: relB1.x* c -relB1.y * s, y: relB1.x* s +relB1.y * c};
-            //            var rotB2 = { x: relB2.x* c -relB2.y * s, y: relB2.x* s +relB2.y * c};
-
-            //					if(!GeometryUtil.almostEqual(rotB1.y, 0, tolerance) || !GeometryUtil.almostEqual(rotB2.y, 0, tolerance)){
-            //						continue;
-            //					}
-
-            //					var min1 = Math.min(0, rotA2x);
-            //        var max1 = Math.max(0, rotA2x);
-
-            //        var min2 = Math.min(rotB1.x, rotB2.x);
-            //        var max2 = Math.max(rotB1.x, rotB2.x);
-
-            //					// not overlapping
-            //					if(min2 >= max1 || max2 <= min1){
-            //						continue;
-            //					}
-
-            //					var len = 0;
-            //        var relC1x = 0;
-            //        var relC2x = 0;
-
-            //					// A is B
-            //					if(GeometryUtil.almostEqual(min1, min2) && GeometryUtil.almostEqual(max1, max2)){
-            //						len = max1-min1;
-            //						relC1x = min1;
-            //						relC2x = max1;
-            //					}
-            //					// A inside B
-            //					else if(min1 > min2 && max1<max2){
-            //						len = max1-min1;
-            //						relC1x = min1;
-            //						relC2x = max1;
-            //					}
-            //					// B inside A
-            //					else if(min2 > min1 && max2<max1){
-            //						len = max2-min2;
-            //						relC1x = min2;
-            //						relC2x = max2;
-            //					}
-            //					else{
-            //						len = Math.max(0, Math.min(max1, max2) - Math.max(min1, min2));
-            //						relC1x = Math.min(max1, max2);
-            //						relC2x = Math.max(min1, min2);		
-            //					}
-
-            //					if(len* len > min2){
-            //						totalLength += len;
-
-            //						var relC1 = { x: relC1x * c2, y: relC1x * s2 };
-            //var relC2 = { x: relC2x * c2, y: relC2x * s2 };
-
-            //var C1 = { x: relC1.x + A1.x, y: relC1.y + A1.y };
-            //var C2 = { x: relC2.x + A1.x, y: relC2.y + A1.y };
-
-            //segments.push([C1, C2]);
-            //					}
-            //				}
-            //			}
-
-            //			if(B.children && B.children.length > 0){
-            //				var child = mergedLength(B.children, p, minlength, tolerance);
-            //totalLength += child.totalLength;
-            //				segments = segments.concat(child.segments);
-            //			}
-            //		}
-            //	}
-
-            //	return {totalLength: totalLength, segments: segments};
             throw new NotImplementedException();
         }
 
@@ -199,27 +54,19 @@ namespace DeepNestLib
         }
 
 
-        public static NFP[] cloneNfp(NFP[] nfp, bool inner = false)
+        public static NFP[] CloneNfp(NFP[] nfp, bool inner = false)
         {
 
             if (!inner)
             {
-                return new[] { clone(nfp.First()) };
+                return [Clone(nfp.First())];
             }
             throw new NotImplementedException();
-            // inner nfp is actually an array of nfps
-            List<NFP> newnfp = new List<NFP>();
-            for (var i = 0; i < nfp.Count(); i++)
-            {
-                //  newnfp.push(clone(nfp[i]));
-            }
-
-            //return newnfp;
         }
-        public static NFP clone(NFP nfp)
+        public static NFP Clone(NFP nfp)
         {
-            NFP newnfp = new NFP();
-            for (var i = 0; i < nfp.length; i++)
+            NFP newnfp = new();
+            for (int i = 0; i < nfp.length; i++)
             {
                 newnfp.AddPoint(new SvgPoint(nfp[i].x, nfp[i].y));
             }
@@ -229,9 +76,9 @@ namespace DeepNestLib
                 newnfp.children = new List<NFP>();
                 for (int i = 0; i < nfp.children.Count; i++)
                 {
-                    var child = nfp.children[i];
+                    NFP child = nfp.children[i];
                     NFP newchild = new NFP();
-                    for (var j = 0; j < child.length; j++)
+                    for (int j = 0; j < child.length; j++)
                     {
                         newchild.AddPoint(new SvgPoint(child[j].x, child[j].y));
                     }
@@ -248,9 +95,9 @@ namespace DeepNestLib
         public static ConcurrentDictionary<string, NFP[]> cacheProcess = new ConcurrentDictionary<string, NFP[]>();
         public static NFP[] Process2(NFP A, NFP B, int type)
         {
-            var key = A.source + ";" + B.source + ";" + A.rotation + ";" + B.rotation;
+            string key = A.source + ";" + B.source + ";" + A.rotation + ";" + B.rotation;
             bool cacheAllow = type != 1;
-            if (cacheAllow && cacheProcess.TryGetValue(key, out var cachedValue))
+            if (cacheAllow && cacheProcess.TryGetValue(key, out NFP[]? cachedValue))
             {
                 return cachedValue;
             }
@@ -259,33 +106,33 @@ namespace DeepNestLib
             Dictionary<string, List<PointF>> dic1 = new Dictionary<string, List<PointF>>();
             Dictionary<string, List<double>> dic2 = new Dictionary<string, List<double>>();
             dic2.Add("A", new List<double>());
-            foreach (var item in A.Points)
+            foreach (SvgPoint item in A.Points)
             {
-                var target = dic2["A"];
+                List<double> target = dic2["A"];
                 target.Add(item.x);
                 target.Add(item.y);
             }
             dic2.Add("B", new List<double>());
-            foreach (var item in B.Points)
+            foreach (SvgPoint item in B.Points)
             {
-                var target = dic2["B"];
+                List<double> target = dic2["B"];
                 target.Add(item.x);
                 target.Add(item.y);
             }
 
             List<double> hdat = new List<double>();
-            foreach (var item in A.children)
+            foreach (NFP item in A.children)
             {
-                foreach (var pitem in item.Points)
+                foreach (SvgPoint pitem in item.Points)
                 {
                     hdat.Add(pitem.x);
                     hdat.Add(pitem.y);
                 }
             }
 
-            var aa = dic2["A"];
-            var bb = dic2["B"];
-            var arr1 = A.children.Select(z => z.Points.Count() * 2).ToArray();
+            List<double> aa = dic2["A"];
+            List<double> bb = dic2["B"];
+            int[] arr1 = A.children.Select(z => z.Points.Count() * 2).ToArray();
 
             MinkowskiWrapper.setData(aa.Count, aa.ToArray(), A.children.Count, arr1, hdat.ToArray(), bb.Count, bb.ToArray());
             MinkowskiWrapper.calculateNFP();
@@ -318,8 +165,8 @@ namespace DeepNestLib
                 List<PointF> Apts = new List<PointF>();
                 for (int i = 0; i < dat1.Length; i += 2)
                 {
-                    var x1 = (float)dat1[i];
-                    var y1 = (float)dat1[i + 1];
+                    float x1 = (float)dat1[i];
+                    float y1 = (float)dat1[i + 1];
                     Apts.Add(new PointF(x1, y1));
                 }
 
@@ -336,30 +183,30 @@ namespace DeepNestLib
                 }
 
                 List<List<PointF>> holesout = new List<List<PointF>>();
-                foreach (var item in holesval)
+                foreach (List<double> item in holesval)
                 {
                     holesout.Add(new List<PointF>());
                     for (int i = 0; i < item.Count; i += 2)
                     {
-                        var x = (float)item[i];
-                        var y = (float)item[i + 1];
+                        float x = (float)item[i];
+                        float y = (float)item[i + 1];
                         holesout.Last().Add(new PointF(x, y));
                     }
                 }
 
                 ret = new NFP();
                 ret.Points = new SvgPoint[] { };
-                foreach (var item in Apts)
+                foreach (PointF item in Apts)
                 {
                     ret.AddPoint(new SvgPoint(item.X, item.Y));
                 }
 
-                foreach (var item in holesout)
+                foreach (List<PointF> item in holesout)
                 {
                     ret.children = new List<NFP>();
                     ret.children.Add(new NFP());
                     ret.children.Last().Points = new SvgPoint[] { };
-                    foreach (var hitem in item)
+                    foreach (PointF hitem in item)
                     {
                         ret.children.Last().AddPoint(new SvgPoint(hitem.X, hitem.Y));
                     }
@@ -375,8 +222,8 @@ namespace DeepNestLib
             // Now 'ret' holds the processed data, and the temporary arrays have been safely returned.
 
             swg.Stop();
-            var msg = swg.ElapsedMilliseconds;
-            var res = new NFP[] { ret };
+            long msg = swg.ElapsedMilliseconds;
+            NFP[] res = new NFP[] { ret };
 
             if (cacheAllow)
             {
@@ -385,9 +232,9 @@ namespace DeepNestLib
             return res;
         }
 
-        public static NFP getFrame(NFP A)
+        public static NFP GetFrame(NFP A)
         {
-            var bounds = GeometryUtil.getPolygonBounds(A);
+            PolygonBounds bounds = GeometryUtil.getPolygonBounds(A);
 
             // expand bounds by 10%
             bounds.width *= 1.1;
@@ -395,7 +242,7 @@ namespace DeepNestLib
             bounds.x -= 0.5 * (bounds.width - (bounds.width / 1.1));
             bounds.y -= 0.5 * (bounds.height - (bounds.height / 1.1));
 
-            var frame = new NFP();
+            NFP frame = new NFP();
             frame.push(new SvgPoint(bounds.x, bounds.y));
             frame.push(new SvgPoint(bounds.x + bounds.width, bounds.y));
             frame.push(new SvgPoint(bounds.x + bounds.width, bounds.y + bounds.height));
@@ -409,12 +256,12 @@ namespace DeepNestLib
             return frame;
         }
 
-        public static NFP[] getInnerNfp(NFP A, NFP B, int type, SvgNestConfig config)
+        public static NFP[] GetInnerNfp(NFP A, NFP B, int type, SvgNestConfig config)
         {
             if (A.source != null && B.source != null)
             {
 
-                var key = new DbCacheKey()
+                DbCacheKey key = new DbCacheKey()
                 {
                     A = A.source.Value,
                     B = B.source.Value,
@@ -423,7 +270,7 @@ namespace DeepNestLib
                     //Inside =true??
                 };
                 //var doc = window.db.find({ A: A.source, B: B.source, Arotation: 0, Brotation: B.rotation }, true);
-                var res = window.db.find(key, true);
+                NFP[] res = window.db.Find(key, true);
                 if (res != null)
                 {
                     return res;
@@ -431,9 +278,9 @@ namespace DeepNestLib
             }
 
 
-            var frame = getFrame(A);
+            NFP frame = GetFrame(A);
 
-            var nfp = getOuterNfp(frame, B, type, true);
+            NFP nfp = GetOuterNfp(frame, B, type, true);
 
             if (nfp == null || nfp.children == null || nfp.children.Count == 0)
             {
@@ -442,9 +289,9 @@ namespace DeepNestLib
             List<NFP> holes = new List<NFP>();
             if (A.children != null && A.children.Count > 0)
             {
-                for (var i = 0; i < A.children.Count; i++)
+                for (int i = 0; i < A.children.Count; i++)
                 {
-                    var hnfp = getOuterNfp(A.children[i], B, 1);
+                    NFP hnfp = GetOuterNfp(A.children[i], B, 1);
                     if (hnfp != null)
                     {
                         holes.Add(hnfp);
@@ -456,11 +303,11 @@ namespace DeepNestLib
             {
                 return nfp.children.ToArray();
             }
-            var clipperNfp = innerNfpToClipperCoordinates(nfp.children.ToArray(), config);
-            var clipperHoles = innerNfpToClipperCoordinates(holes.ToArray(), config);
+            IntPoint[][] clipperNfp = InnerNfpToClipperCoordinates(nfp.children.ToArray(), config);
+            IntPoint[][] clipperHoles = InnerNfpToClipperCoordinates(holes.ToArray(), config);
 
             List<List<IntPoint>> finalNfp = new List<List<IntPoint>>();
-            var clipper = new ClipperLib.Clipper();
+            Clipper clipper = new ClipperLib.Clipper();
 
             clipper.AddPaths(clipperHoles.Select(z => z.ToList()).ToList(), ClipperLib.PolyType.ptClip, true);
             clipper.AddPaths(clipperNfp.Select(z => z.ToList()).ToList(), ClipperLib.PolyType.ptSubject, true);
@@ -476,16 +323,15 @@ namespace DeepNestLib
             }
 
             List<NFP> f = new List<NFP>();
-            for (var i = 0; i < finalNfp.Count; i++)
+            for (int i = 0; i < finalNfp.Count; i++)
             {
-                f.Add(toNestCoordinates(finalNfp[i].ToArray(), config.ClipperScale));
+                f.Add(ToNestCoordinates(finalNfp[i].ToArray(), config.ClipperScale));
             }
 
             if (A.source != null && B.source != null)
             {
                 // insert into db
-                //console.log('inserting inner: ', A.source, B.source, B.rotation, f);
-                var doc = new DbCacheKey()
+                DbCacheKey doc = new DbCacheKey()
                 {
                     A = A.source.Value,
                     B = B.source.Value,
@@ -495,24 +341,24 @@ namespace DeepNestLib
 
 
                 };
-                window.db.insert(doc, true);
+                window.db.Insert(doc, true);
             }
 
             return f.ToArray();
 
         }
-        public static NFP rotatePolygon(NFP polygon, float degrees)
+        public static NFP RotatePolygon(NFP polygon, float degrees)
         {
             NFP rotated = new NFP();
 
-            var angle = degrees * Math.PI / 180;
+            double angle = degrees * Math.PI / 180;
             List<SvgPoint> pp = new List<SvgPoint>(polygon.length);
-            for (var i = 0; i < polygon.length; i++)
+            for (int i = 0; i < polygon.length; i++)
             {
-                var x = polygon[i].x;
-                var y = polygon[i].y;
-                var x1 = (x * Math.Cos(angle) - y * Math.Sin(angle));
-                var y1 = (x * Math.Sin(angle) + y * Math.Cos(angle));
+                double x = polygon[i].x;
+                double y = polygon[i].y;
+                double x1 = (x * Math.Cos(angle) - y * Math.Sin(angle));
+                double y1 = (x * Math.Sin(angle) + y * Math.Cos(angle));
 
                 pp.Add(new SvgPoint(x1, y1));
             }
@@ -521,19 +367,21 @@ namespace DeepNestLib
             if (polygon.children != null && polygon.children.Count > 0)
             {
                 rotated.children = new List<NFP>(); ;
-                for (var j = 0; j < polygon.children.Count; j++)
+                for (int j = 0; j < polygon.children.Count; j++)
                 {
-                    rotated.children.Add(rotatePolygon(polygon.children[j], degrees));
+                    rotated.children.Add(RotatePolygon(polygon.children[j], degrees));
                 }
             }
 
             return rotated;
         }
 
-        public static SheetPlacement placeParts(NFP[] sheets, NFP[] parts, SvgNestConfig config, int nestindex, CancellationToken cancellationToken)
+        public static SheetPlacement PlaceParts(NFP[] sheets, NFP[] parts, SvgNestConfig config, int nestindex, CancellationToken cancellationToken)
         {
-            if (sheets == null || sheets.Count() == 0) return null;
-
+            if (sheets == null || sheets.Count() == 0)
+            {
+                return null;
+            }
 
             int i, j, k, m, n;
             double totalsheetarea = 0;
@@ -543,10 +391,10 @@ namespace DeepNestLib
             double totalMerged = 0;
 
             // rotate paths by given rotation
-            var rotated = new List<NFP>();
+            List<NFP> rotated = new List<NFP>();
             for (i = 0; i < parts.Length; i++)
             {
-                var r = rotatePolygon(parts[i], parts[i].rotation);
+                NFP r = RotatePolygon(parts[i], parts[i].rotation);
                 r.Rotation = parts[i].rotation;
                 r.source = parts[i].source;
                 r.Id = parts[i].Id;
@@ -571,7 +419,7 @@ namespace DeepNestLib
                 List<PlacementItem> placements = new List<PlacementItem>();
 
                 // open a new sheet
-                var sheet = sheets.First();
+                NFP sheet = sheets.First();
                 sheets = sheets.Skip(1).ToArray();
                 sheetarea = Math.Abs(GeometryUtil.polygonArea(sheet));
                 totalsheetarea += sheetarea;
@@ -580,9 +428,9 @@ namespace DeepNestLib
 
                 string clipkey = "";
                 Dictionary<string, ClipCacheItem> clipCache = new Dictionary<string, ClipCacheItem>();
-                var clipper = new ClipperLib.Clipper();
-                var combinedNfp = new List<List<ClipperLib.IntPoint>>();
-                var error = false;
+                Clipper clipper = new ClipperLib.Clipper();
+                List<List<IntPoint>> combinedNfp = new List<List<ClipperLib.IntPoint>>();
+                bool error = false;
                 IntPoint[][] clipperSheetNfp = null;
                 double? minwidth = null;
                 PlacementItem position = null;
@@ -600,7 +448,7 @@ namespace DeepNestLib
                     // (only do this for the first part of each sheet, to ensure that all parts that can be placed are, even if we have to to open a lot of sheets)
                     for (j = 0; j < (360f / config.Rotations); j++)
                     {
-                        sheetNfp = getInnerNfp(sheet, part, 0, config);
+                        sheetNfp = GetInnerNfp(sheet, part, 0, config);
 
                         if (sheetNfp != null && sheetNfp.Count() > 0)
                         {
@@ -614,7 +462,7 @@ namespace DeepNestLib
                             }
                         }
 
-                        var r = rotatePolygon(part, 360f / config.Rotations);
+                        NFP r = RotatePolygon(part, 360f / config.Rotations);
                         r.rotation = part.rotation + (360f / config.Rotations);
                         r.source = part.source;
                         r.id = part.id;
@@ -677,7 +525,7 @@ namespace DeepNestLib
                         continue;
                     }
 
-                    clipperSheetNfp = innerNfpToClipperCoordinates(sheetNfp, config);
+                    clipperSheetNfp = InnerNfpToClipperCoordinates(sheetNfp, config);
 
                     clipper = new ClipperLib.Clipper();
                     combinedNfp = new List<List<ClipperLib.IntPoint>>();
@@ -685,19 +533,18 @@ namespace DeepNestLib
                     error = false;
 
                     // check if stored in clip cache
-                    //var startindex = 0;
                     clipkey = "s:" + part.source + "r:" + part.rotation;
-                    var startindex = 0;
+                    int startindex = 0;
                     if (EnableCaches && clipCache.ContainsKey(clipkey))
                     {
-                        var prevNfp = clipCache[clipkey].nfpp;
+                        IntPoint[][] prevNfp = clipCache[clipkey].Nfpp;
                         clipper.AddPaths(prevNfp.Select(z => z.ToList()).ToList(), ClipperLib.PolyType.ptSubject, true);
                         startindex = clipCache[clipkey].index;
                     }
 
                     for (j = startindex; j < placed.Count; j++)
                     {
-                        nfp = getOuterNfp(placed[j], part, 0);
+                        nfp = GetOuterNfp(placed[j], part, 0);
                         // minkowski difference failed. very rare but could happen
                         if (nfp == null)
                         {
@@ -714,7 +561,7 @@ namespace DeepNestLib
                         {
                             for (n = 0; n < nfp.children.Count; n++)
                             {
-                                for (var o = 0; o < nfp.children[n].length; o++)
+                                for (int o = 0; o < nfp.children[n].length; o++)
                                 {
                                     nfp.children[n][o].x += placements[j].x;
                                     nfp.children[n][o].y += placements[j].y;
@@ -722,15 +569,13 @@ namespace DeepNestLib
                             }
                         }
 
-                        var clipperNfp = nfpToClipperCoordinates(nfp, config);
+                        IntPoint[][] clipperNfp = NfpToClipperCoordinates(nfp, config);
 
                         clipper.AddPaths(clipperNfp.Select(z => z.ToList()).ToList(), ClipperLib.PolyType.ptSubject, true);
                     }
-                    //TODO: a lot here to insert
 
                     if (error || !clipper.Execute(ClipperLib.ClipType.ctUnion, combinedNfp, ClipperLib.PolyFillType.pftNonZero, ClipperLib.PolyFillType.pftNonZero))
                     {
-                        //console.log('clipper error', error);
                         continue;
                     }
 
@@ -740,11 +585,9 @@ namespace DeepNestLib
                         clipCache[clipkey] = new ClipCacheItem()
                         {
                             index = placed.Count - 1,
-                            nfpp = combinedNfp.Select(z => z.ToArray()).ToArray()
+                            Nfpp = combinedNfp.Select(z => z.ToArray()).ToArray()
                         };
                     }
-
-                    //console.log('save cache', placed.length - 1);
 
                     // difference with sheet polygon
                     List<List<IntPoint>> _finalNfp = new List<List<IntPoint>>();
@@ -770,18 +613,12 @@ namespace DeepNestLib
                     for (j = 0; j < _finalNfp.Count; j++)
                     {
                         // back to normal scale
-                        f.Add(Background.toNestCoordinates(_finalNfp[j].ToArray(), config.ClipperScale));
+                        f.Add(ToNestCoordinates(_finalNfp[j].ToArray(), config.ClipperScale));
                     }
-                    var finalNfp = f;
-                    //finalNfp = f;
+                    List<NFP> finalNfp = f;
 
                     // choose placement that results in the smallest bounding box/hull etc
                     // todo: generalize gravity direction
-                    /*var minwidth = null;
-                    var minarea = null;
-                    var minx = null;
-                    var miny = null;
-                    var nf, area, shiftvector;*/
                     minwidth = null;
                     minarea = null;
                     double? minx = null;
@@ -822,7 +659,6 @@ namespace DeepNestLib
                     for (j = 0; j < finalNfp.Count; j++)
                     {
                         nf = finalNfp[j];
-                        //console.log('evalnf',nf.length);
                         for (k = 0; k < nf.length; k++)
                         {
                             shiftvector = new PlacementItem()
@@ -841,27 +677,10 @@ namespace DeepNestLib
                                 poly.AddPoint(new SvgPoint(allbounds.x + allbounds.width, allbounds.y));
                                 poly.AddPoint(new SvgPoint(allbounds.x + allbounds.width, allbounds.y + allbounds.height));
                                 poly.AddPoint(new SvgPoint(allbounds.x, allbounds.y + allbounds.height));
-                                /*
-                             [
-                                // allbounds points
-                            { x: allbounds.x, y: allbounds.y},
-                            { x: allbounds.x + allbounds.width, y: allbounds.y},
-                            { x: allbounds.x + allbounds.width, y: allbounds.y + allbounds.height},
-                            { x: allbounds.x, y: allbounds.y + allbounds.height},*/
-
                                 poly.AddPoint(new SvgPoint(partbounds.x + shiftvector.x, partbounds.y + shiftvector.y));
                                 poly.AddPoint(new SvgPoint(partbounds.x + partbounds.width + shiftvector.x, partbounds.y + shiftvector.y));
                                 poly.AddPoint(new SvgPoint(partbounds.x + partbounds.width + shiftvector.x, partbounds.y + partbounds.height + shiftvector.y));
                                 poly.AddPoint(new SvgPoint(partbounds.x + shiftvector.x, partbounds.y + partbounds.height + shiftvector.y));
-                                /*
-                                 [                            
-
-                                // part points
-                                { x: partbounds.x + shiftvector.x, y: partbounds.y + shiftvector.y},
-                                { x: partbounds.x + partbounds.width + shiftvector.x, y: partbounds.y + shiftvector.y},
-                                { x: partbounds.x + partbounds.width + shiftvector.x, y: partbounds.y + partbounds.height + shiftvector.y},
-                                { x: partbounds.x + shiftvector.x, y: partbounds.y + partbounds.height + shiftvector.y}
-                            ]*/
                                 rectbounds = GeometryUtil.getPolygonBounds(poly);
 
                                 // weigh width more, to help compress in direction of gravity
@@ -877,7 +696,7 @@ namespace DeepNestLib
                             else
                             {
                                 // must be convex hull
-                                var localpoints = clone(allpoints);
+                                NFP localpoints = Clone(allpoints);
 
                                 for (m = 0; m < part.length; m++)
                                 {
@@ -888,28 +707,12 @@ namespace DeepNestLib
                                 shiftvector.hull = getHull(localpoints);
                                 shiftvector.hullsheet = getHull(sheet);
                             }
-                            //console.timeEnd('evalbounds');
-                            //console.time('evalmerge');
                             MergedResult merged = null;
                             if (config.MergeLines)
                             {
                                 throw new NotImplementedException();
-                                // if lines can be merged, subtract savings from area calculation						
-                                var shiftedpart = shiftPolygon(part, shiftvector);
-                                List<NFP> shiftedplaced = new List<NFP>();
-
-                                for (m = 0; m < placed.Count; m++)
-                                {
-                                    shiftedplaced.Add(shiftPolygon(placed[m], placements[m]));
-                                }
-
-                                // don't check small lines, cut off at about 1/2 in
-                                double minlength = 0.5 * config.Scale;
-                                merged = mergedLength(shiftedplaced.ToArray(), shiftedpart, minlength, 0.1 * config.CurveTolerance);
-                                area -= merged.totalLength * config.TimeRatio;
                             }
 
-                            //console.timeEnd('evalmerge');
                             if (
                     minarea == null ||
                     area < minarea ||
@@ -951,17 +754,12 @@ namespace DeepNestLib
                         }
                     }
                     // send placement progress signal
-                    var placednum = placed.Count;
+                    int placednum = placed.Count;
                     for (j = 0; j < allplacements.Count; j++)
                     {
                         placednum += allplacements[j].sheetplacements.Count;
                     }
-                    //console.log(placednum, totalnum);
-                    //ipcRenderer.send('background-progress', { index: nestindex, progress: 0.5 + 0.5 * (placednum / totalnum)});
-
-                    //console.timeEnd('placement');
                 }
-                //if(minwidth){
                 if (!minwidth.HasValue)
                 {
                     fitness = double.NaN;
@@ -971,12 +769,11 @@ namespace DeepNestLib
                     fitness += (minwidth.Value / sheetarea) + minarea.Value;
                 }
 
-                //}
                 for (i = 0; i < placed.Count; i++)
                 {
 
 
-                    var index = Array.IndexOf(parts, placed[i]);
+                    int index = Array.IndexOf(parts, placed[i]);
                     if (index >= 0)
                     {
                         parts = parts.splice(index, 1);
@@ -990,7 +787,6 @@ namespace DeepNestLib
                         sheetSource = sheet.source.Value,
                         sheetplacements = placements
                     });
-                    //allplacements.Add({ sheet: sheet.source, sheetid: sheet.id, sheetplacements: placements});
                 }
                 else
                 {
@@ -1009,9 +805,6 @@ namespace DeepNestLib
             {
                 fitness += 100000000 * (Math.Abs(GeometryUtil.polygonArea(parts[i])) / totalsheetarea);
             }
-            // send finish progerss signal
-            //ipcRenderer.send('background-progress', { index: nestindex, progress: -1});
-
 
             return new SheetPlacement()
             {
@@ -1023,8 +816,8 @@ namespace DeepNestLib
 
 
             };
-            //return { placements: allplacements, fitness: fitness, area: sheetarea, mergedLength: totalMerged };
         }
+
         // jsClipper uses X/Y instead of x/y...
         public DataInfo data;
         NFP[] parts;
@@ -1035,52 +828,48 @@ namespace DeepNestLib
         // run the placement synchronously
 
 
-        public static windowUnk window = new windowUnk();
+        public static WindowUnk window = new();
 
         public Action<SheetPlacement> ResponseAction;
 
         public static long LastPlacePartTime = 0;
-        public void sync(CancellationToken cancellationToken)
+        public void Sync(CancellationToken cancellationToken)
         {
-            //console.log('starting synchronous calculations', Object.keys(window.nfpCache).length);
-            //console.log('in sync');
-            var c = 0;
-            foreach (var key in window.nfpCache)
+            int c = 0;
+            foreach (KeyValuePair<NfpCacheKey, List<NFP>> key in window.nfpCache)
             {
                 c++;
             }
-            //console.log('nfp cached:', c);
             Stopwatch sw = Stopwatch.StartNew();
-            var placement = placeParts(data.sheets.ToArray(), parts, data.config, index, cancellationToken);
+            SheetPlacement placement = PlaceParts(data.sheets.ToArray(), parts, data.config, index, cancellationToken);
             sw.Stop();
             LastPlacePartTime = sw.ElapsedMilliseconds;
 
             placement.index = data.index;
             ResponseAction(placement);
-            //ipcRenderer.send('background-response', placement);
         }
         public void BackgroundStart(DataInfo data, CancellationToken cancellationToken)
         {
             this.data = data;
-            var index = data.index;
-            var individual = data.individual;
+            int index = data.index;
+            PopulationItem individual = data.individual;
 
-            var parts = individual.placements;
+            List<NFP> parts = individual.placements;
 
-            var pairs = new List<NfpPair>();
+            List<NfpPair> pairs = new List<NfpPair>();
 
             if (UseParallel)
             {
-                var concurrentPairs = new ConcurrentBag<NfpPair>();
+                ConcurrentBag<NfpPair> concurrentPairs = new ConcurrentBag<NfpPair>();
 
                 Parallel.For(0, parts.Count, i =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var B = parts[i];
-                    for (var j = 0; j < i; j++)
+                    NFP B = parts[i];
+                    for (int j = 0; j < i; j++)
                     {
-                        var A = parts[j];
-                        var key = new NfpPair()
+                        NFP A = parts[j];
+                        NfpPair key = new NfpPair()
                         {
                             A = A,
                             B = B,
@@ -1089,7 +878,7 @@ namespace DeepNestLib
                             Asource = A.source.Value,
                             Bsource = B.source.Value
                         };
-                        var doc = new DbCacheKey()
+                        DbCacheKey doc = new DbCacheKey()
                         {
                             A = A.source.Value,
                             B = B.source.Value,
@@ -1097,7 +886,7 @@ namespace DeepNestLib
                             BRotation = B.rotation
                         };
 
-                        if (!window.db.has(doc))
+                        if (!window.db.Has(doc))
                         {
                             concurrentPairs.Add(key);
                         }
@@ -1111,14 +900,14 @@ namespace DeepNestLib
             }
             else
             {
-                for (var i = 0; i < parts.Count; i++)
+                for (int i = 0; i < parts.Count; i++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var B = parts[i];
-                    for (var j = 0; j < i; j++)
+                    NFP B = parts[i];
+                    for (int j = 0; j < i; j++)
                     {
-                        var A = parts[j];
-                        var key = new NfpPair()
+                        NFP A = parts[j];
+                        NfpPair key = new NfpPair()
                         {
                             A = A,
                             B = B,
@@ -1128,7 +917,7 @@ namespace DeepNestLib
                             Bsource = B.source.Value
 
                         };
-                        var doc = new DbCacheKey()
+                        DbCacheKey doc = new DbCacheKey()
                         {
                             A = A.source.Value,
                             B = B.source.Value,
@@ -1137,7 +926,7 @@ namespace DeepNestLib
                             BRotation = B.rotation
 
                         };
-                        if (!inpairs(key, pairs.ToArray()) && !window.db.has(doc))
+                        if (!Inpairs(key, pairs.ToArray()) && !window.db.Has(doc))
                         {
                             pairs.Add(key);
                         }
@@ -1148,18 +937,18 @@ namespace DeepNestLib
             this.parts = parts.ToArray();
             if (pairs.Count > 0)
             {
-                var ret1 = pmapDeepNest(pairs, cancellationToken);
-                thenDeepNest(ret1, parts, cancellationToken);
+                NfpPair[] ret1 = PmapDeepNest(pairs, cancellationToken);
+                ThenDeepNest(ret1, parts, cancellationToken);
             }
             else
             {
-                sync(cancellationToken);
+                Sync(cancellationToken);
             }
         }
 
-        public NFP getPart(int source, List<NFP> parts)
+        public NFP GetPart(int source, List<NFP> parts)
         {
-            for (var k = 0; k < parts.Count; k++)
+            for (int k = 0; k < parts.Count; k++)
             {
                 if (parts[k].source == source)
                 {
@@ -1169,13 +958,13 @@ namespace DeepNestLib
             return null;
         }
 
-        public void thenIterate(NfpPair processed, List<NFP> parts)
+        public void ThenIterate(NfpPair processed, List<NFP> parts)
         {
 
             // returned data only contains outer nfp, we have to account for any holes separately in the synchronous portion
             // this is because the c++ addon which can process interior nfps cannot run in the worker thread					
-            var A = getPart(processed.Asource, parts);
-            var B = getPart(processed.Bsource, parts);
+            NFP A = GetPart(processed.Asource, parts);
+            NFP B = GetPart(processed.Bsource, parts);
 
             List<NFP> Achildren = new List<NFP>();
 
@@ -1184,22 +973,22 @@ namespace DeepNestLib
             {
                 for (int j = 0; j < A.children.Count; j++)
                 {
-                    Achildren.Add(rotatePolygon(A.children[j], processed.ARotation));
+                    Achildren.Add(RotatePolygon(A.children[j], processed.ARotation));
                 }
             }
 
             if (Achildren.Count > 0)
             {
-                var Brotated = rotatePolygon(B, processed.BRotation);
-                var bbounds = GeometryUtil.getPolygonBounds(Brotated);
+                NFP Brotated = RotatePolygon(B, processed.BRotation);
+                PolygonBounds bbounds = GeometryUtil.getPolygonBounds(Brotated);
                 List<NFP> cnfp = new List<NFP>();
 
                 for (int j = 0; j < Achildren.Count; j++)
                 {
-                    var cbounds = GeometryUtil.getPolygonBounds(Achildren[j]);
+                    PolygonBounds cbounds = GeometryUtil.getPolygonBounds(Achildren[j]);
                     if (cbounds.width > bbounds.width && cbounds.height > bbounds.height)
                     {
-                        var n = getInnerNfp(Achildren[j], Brotated, 1, data.config);
+                        NFP[] n = GetInnerNfp(Achildren[j], Brotated, 1, data.config);
                         if (n != null && n.Count() > 0)
                         {
                             cnfp.AddRange(n);
@@ -1218,15 +1007,7 @@ namespace DeepNestLib
                 nfp = new[] { processed.nfp }
             };
 
-            /*var doc = {
-                    A: processed[i].Asource,
-                    B: processed[i].Bsource,
-                    Arotation: processed[i].Arotation,
-                    Brotation: processed[i].Brotation,
-                    nfp: processed[i].nfp
-
-                };*/
-            window.db.insert(doc);
+            window.db.Insert(doc);
         }
 
         public static Action<float> displayProgress;
@@ -1237,7 +1018,7 @@ namespace DeepNestLib
                 displayProgress(p);
             }
         }
-        public void thenDeepNest(NfpPair[] processed, List<NFP> parts, CancellationToken token)
+        public void ThenDeepNest(NfpPair[] processed, List<NFP> parts, CancellationToken token)
         {
             int cnt = 0;
             if (UseParallel)
@@ -1247,27 +1028,27 @@ namespace DeepNestLib
                     float progress = 0.33f + 0.33f * (cnt / (float)processed.Count());
                     cnt++;
                     DisplayProgress(progress);
-                    thenIterate(item, parts);
+                    ThenIterate(item, parts);
                 });
             }
             else
             {
-                for (var i = 0; i < processed.Length; i++)
+                for (int i = 0; i < processed.Length; i++)
                 {
                     float progress = 0.33f + 0.33f * (cnt / (float)processed.Count());
                     cnt++;
                     DisplayProgress(progress);
-                    thenIterate(processed[i], parts);
+                    ThenIterate(processed[i], parts);
                 }
             }
 
-            sync(token);
+            Sync(token);
         }
 
 
-        public bool inpairs(NfpPair key, NfpPair[] p)
+        public bool Inpairs(NfpPair key, NfpPair[] p)
         {
-            for (var i = 0; i < p.Length; i++)
+            for (int i = 0; i < p.Length; i++)
             {
                 if (p[i].Asource == key.Asource && p[i].Bsource == key.Bsource && p[i].ARotation == key.ARotation && p[i].BRotation == key.BRotation)
                 {
@@ -1277,7 +1058,7 @@ namespace DeepNestLib
             return false;
         }
 
-        public NfpPair[] pmapDeepNest(List<NfpPair> pairs, CancellationToken cancellationToken)
+        public NfpPair[] PmapDeepNest(List<NfpPair> pairs, CancellationToken cancellationToken)
         {
 
 
@@ -1293,7 +1074,7 @@ namespace DeepNestLib
                         return;
                     }
 
-                    ret[i] = process(pairs[i], cancellationToken);
+                    ret[i] = Process(pairs[i], cancellationToken);
                     float progress = 0.33f * (cnt / (float)pairs.Count);
                     cnt++;
                     DisplayProgress(progress);
@@ -1305,8 +1086,8 @@ namespace DeepNestLib
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var item = pairs[i];
-                    ret[i] = process(item, cancellationToken);
+                    NfpPair item = pairs[i];
+                    ret[i] = Process(item, cancellationToken);
                     float progress = 0.33f * (cnt / (float)pairs.Count);
                     cnt++;
                     DisplayProgress(progress);
@@ -1315,30 +1096,30 @@ namespace DeepNestLib
             cancellationToken.ThrowIfCancellationRequested();
             return ret.ToArray();
         }
-        public NfpPair process(NfpPair pair, CancellationToken cancellationToken)
+
+        public NfpPair Process(NfpPair pair, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var A = rotatePolygon(pair.A, pair.ARotation);
-            var B = rotatePolygon(pair.B, pair.BRotation);
+            NFP A = RotatePolygon(pair.A, pair.ARotation);
+            NFP B = RotatePolygon(pair.B, pair.BRotation);
 
-            ///////////////////
-            var Ac = _Clipper.ScaleUpPaths(A, 10000000);
+            IntPoint[] Ac = _Clipper.ScaleUpPaths(A, 10000000);
 
-            var Bc = _Clipper.ScaleUpPaths(B, 10000000);
-            for (var i = 0; i < Bc.Length; i++)
+            IntPoint[] Bc = _Clipper.ScaleUpPaths(B, 10000000);
+            for (int i = 0; i < Bc.Length; i++)
             {
                 Bc[i].X *= -1;
                 Bc[i].Y *= -1;
             }
-            var solution = ClipperLib.Clipper.MinkowskiSum(new List<IntPoint>(Ac), new List<IntPoint>(Bc), true);
+            List<List<IntPoint>> solution = ClipperLib.Clipper.MinkowskiSum(new List<IntPoint>(Ac), new List<IntPoint>(Bc), true);
             NFP clipperNfp = null;
 
             double? largestArea = null;
             for (int i = 0; i < solution.Count(); i++)
             {
-                var n = toNestCoordinates(solution[i].ToArray(), 10000000);
-                var sarea = -GeometryUtil.polygonArea(n);
+                NFP n = ToNestCoordinates(solution[i].ToArray(), 10000000);
+                double sarea = -GeometryUtil.polygonArea(n);
                 if (largestArea == null || largestArea < sarea)
                 {
                     clipperNfp = n;
@@ -1346,15 +1127,11 @@ namespace DeepNestLib
                 }
             }
 
-            for (var i = 0; i < clipperNfp.length; i++)
+            for (int i = 0; i < clipperNfp.length; i++)
             {
                 clipperNfp[i].x += B[0].x;
                 clipperNfp[i].y += B[0].y;
             }
-
-            //return new SvgNestPort.NFP[] { new SvgNestPort.NFP() { Points = clipperNfp.Points } };
-
-            //////////////
 
             pair.A = null;
             pair.B = null;
@@ -1363,11 +1140,11 @@ namespace DeepNestLib
 
 
         }
-        public static NFP toNestCoordinates(IntPoint[] polygon, double scale)
+        public static NFP ToNestCoordinates(IntPoint[] polygon, double scale)
         {
-            var clone = new List<SvgPoint>();
+            List<SvgPoint> clone = new List<SvgPoint>();
 
-            for (var i = 0; i < polygon.Count(); i++)
+            for (int i = 0; i < polygon.Count(); i++)
             {
                 clone.Add(new SvgPoint(
                      polygon[i].X / scale,
@@ -1378,20 +1155,13 @@ namespace DeepNestLib
         }
         public static NFP getHull(NFP polygon)
         {
-            // convert to hulljs format
-            /*var hull = new ConvexHullGrahamScan();
-            for(var i=0; i<polygon.length; i++){
-                hull.addPoint(polygon[i].x, polygon[i].y);
-            }
-
-            return hull.getHull();*/
             double[][] points = new double[polygon.length][];
-            for (var i = 0; i < polygon.length; i++)
+            for (int i = 0; i < polygon.length; i++)
             {
                 points[i] = (new double[] { polygon[i].x, polygon[i].y });
             }
 
-            var hullpoints = D3.polygonHull(points);
+            double[][] hullpoints = D3.polygonHull(points);
 
             if (hullpoints == null)
             {
@@ -1408,7 +1178,7 @@ namespace DeepNestLib
 
 
         // returns clipper nfp. Remember that clipper nfp are a list of polygons, not a tree!
-        public static IntPoint[][] nfpToClipperCoordinates(NFP nfp, SvgNestConfig config)
+        public static IntPoint[][] NfpToClipperCoordinates(NFP nfp, SvgNestConfig config)
         {
 
             List<IntPoint[]> clipperNfp = new List<IntPoint[]>();
@@ -1416,14 +1186,14 @@ namespace DeepNestLib
             // children first
             if (nfp.children != null && nfp.children.Count > 0)
             {
-                for (var j = 0; j < nfp.children.Count; j++)
+                for (int j = 0; j < nfp.children.Count; j++)
                 {
                     if (GeometryUtil.polygonArea(nfp.children[j]) < 0)
                     {
                         nfp.children[j].reverse();
                     }
                     //var childNfp = SvgNest.toClipperCoordinates(nfp.children[j]);
-                    var childNfp = _Clipper.ScaleUpPaths(nfp.children[j], config.ClipperScale);
+                    IntPoint[] childNfp = _Clipper.ScaleUpPaths(nfp.children[j], config.ClipperScale);
                     clipperNfp.Add(childNfp);
                 }
             }
@@ -1433,27 +1203,22 @@ namespace DeepNestLib
                 nfp.reverse();
             }
 
-
-            //var outerNfp = SvgNest.toClipperCoordinates(nfp);
-
             // clipper js defines holes based on orientation
 
-            var outerNfp = _Clipper.ScaleUpPaths(nfp, config.ClipperScale);
-
-            //var cleaned = ClipperLib.Clipper.CleanPolygon(outerNfp, 0.00001*config.clipperScale);
+            IntPoint[] outerNfp = _Clipper.ScaleUpPaths(nfp, config.ClipperScale);
 
             clipperNfp.Add(outerNfp);
-            //var area = Math.abs(ClipperLib.Clipper.Area(cleaned));
 
             return clipperNfp.ToArray();
         }
+
         // inner nfps can be an array of nfps, outer nfps are always singular
-        public static IntPoint[][] innerNfpToClipperCoordinates(NFP[] nfp, SvgNestConfig config)
+        public static IntPoint[][] InnerNfpToClipperCoordinates(NFP[] nfp, SvgNestConfig config)
         {
             List<IntPoint[]> clipperNfp = new List<IntPoint[]>();
-            for (var i = 0; i < nfp.Count(); i++)
+            for (int i = 0; i < nfp.Count(); i++)
             {
-                var clip = nfpToClipperCoordinates(nfp[i], config);
+                IntPoint[][] clip = NfpToClipperCoordinates(nfp[i], config);
                 clipperNfp.AddRange(clip);
                 //clipperNfp = clipperNfp.Concat(new[] { clip }).ToList();
             }
@@ -1461,12 +1226,12 @@ namespace DeepNestLib
             return clipperNfp.ToArray();
         }
 
-        public static NFP getOuterNfp(NFP A, NFP B, int type, bool inside = false)//todo:?inside def?
+        public static NFP GetOuterNfp(NFP A, NFP B, int type, bool inside = false)
         {
             NFP[] nfp = null;
 
 
-            var key = new DbCacheKey()
+            DbCacheKey key = new DbCacheKey()
             {
                 A = A.source,
                 B = B.source,
@@ -1475,46 +1240,34 @@ namespace DeepNestLib
                 //Type = type
             };
 
-            var doc = window.db.find(key);
+            NFP[] doc = window.db.Find(key);
             if (doc != null)
             {
                 return doc.First();
             }
 
-            /*
-
-            // try the file cache if the calculation will take a long time
-            var doc = window.db.find({ A: A.source, B: B.source, Arotation: A.rotation, Brotation: B.rotation });
-
-            if (doc)
-            {
-                return doc;
-            }*/
-
-
-            // not found in cache           
             if (inside || (A.children != null && A.children.Count > 0))
             {
                 nfp = Process2(A, B, type);
             }
             else
             {
-                var Ac = _Clipper.ScaleUpPaths(A, 10000000);
+                IntPoint[] Ac = _Clipper.ScaleUpPaths(A, 10000000);
 
-                var Bc = _Clipper.ScaleUpPaths(B, 10000000);
-                for (var i = 0; i < Bc.Length; i++)
+                IntPoint[] Bc = _Clipper.ScaleUpPaths(B, 10000000);
+                for (int i = 0; i < Bc.Length; i++)
                 {
                     Bc[i].X *= -1;
                     Bc[i].Y *= -1;
                 }
-                var solution = ClipperLib.Clipper.MinkowskiSum(new List<IntPoint>(Ac), new List<IntPoint>(Bc), true);
+                List<List<IntPoint>> solution = ClipperLib.Clipper.MinkowskiSum(new List<IntPoint>(Ac), new List<IntPoint>(Bc), true);
                 NFP clipperNfp = null;
 
                 double? largestArea = null;
                 for (int i = 0; i < solution.Count(); i++)
                 {
-                    var n = Background.toNestCoordinates(solution[i].ToArray(), 10000000);
-                    var sarea = GeometryUtil.polygonArea(n);
+                    NFP n = ToNestCoordinates(solution[i].ToArray(), 10000000);
+                    double sarea = GeometryUtil.polygonArea(n);
                     if (largestArea == null || largestArea > sarea)
                     {
                         clipperNfp = n;
@@ -1522,7 +1275,7 @@ namespace DeepNestLib
                     }
                 }
 
-                for (var i = 0; i < clipperNfp.length; i++)
+                for (int i = 0; i < clipperNfp.length; i++)
                 {
                     clipperNfp[i].x += B[0].x;
                     clipperNfp[i].y += B[0].y;
@@ -1534,27 +1287,17 @@ namespace DeepNestLib
 
             if (nfp == null || nfp.Length == 0)
             {
-                //console.log('holy shit', nfp, A, B, JSON.stringify(A), JSON.stringify(B));
                 return null;
             }
 
             NFP nfps = nfp.First();
-            /*
-            nfp = nfp.pop();
-            */
             if (nfps == null || nfps.Length == 0)
             {
                 return null;
             }
-            /*
-            if (!nfp || nfp.length == 0)
-            {
-                return null;
-            }
-            */
             if (!inside && A.source != null && B.source != null)
             {
-                var doc2 = new DbCacheKey()
+                DbCacheKey doc2 = new DbCacheKey()
                 {
                     A = A.source.Value,
                     B = B.source.Value,
@@ -1562,79 +1305,11 @@ namespace DeepNestLib
                     BRotation = B.rotation,
                     nfp = nfp
                 };
-                window.db.insert(doc2);
+                window.db.Insert(doc2);
 
 
             }
-            /*
-            if (!inside && typeof A.source !== 'undefined' && typeof B.source !== 'undefined')
-            {
-                // insert into db
-                doc = {
-                    A: A.source,
-            B: B.source,
-            Arotation: A.rotation,
-            Brotation: B.rotation,
-            nfp: nfp
-
-        };
-                window.db.insert(doc);
-            }
-            */
             return nfps;
-
-
-
         }
-    }
-
-    public class ClipCacheItem
-    {
-        public int index;
-        public IntPoint[][] nfpp;
-    }
-
-    public class dbCache
-    {
-        public dbCache(windowUnk w)
-        {
-            window = w;
-        }
-
-        public windowUnk window;
-
-        public bool has(DbCacheKey obj)
-        {
-            var key = new NfpCacheKey(obj); // Create the new struct key
-            return window.nfpCache.ContainsKey(key);
-        }
-
-        internal void insert(DbCacheKey obj, bool inner = false)
-        {
-            var key = new NfpCacheKey(obj); // Create the new struct key
-            var value = Background.cloneNfp(obj.nfp, inner).ToList();
-            window.nfpCache.TryAdd(key, value);
-        }
-
-        public NFP[] find(DbCacheKey obj, bool inner = false)
-        {
-            var key = new NfpCacheKey(obj); // Create the new struct key
-            if (window.nfpCache.TryGetValue(key, out List<NFP> cachedNfp))
-            {
-                return Background.cloneNfp(cachedNfp.ToArray(), inner);
-            }
-            return null;
-        }
-    }
-
-    public class windowUnk
-    {
-        public windowUnk()
-        {
-            db = new dbCache(this);
-        }
-
-        public ConcurrentDictionary<NfpCacheKey, List<NFP>> nfpCache = new ConcurrentDictionary<NfpCacheKey, List<NFP>>();
-        public dbCache db;
     }
 }

--- a/src/DeepNestLib/SvgNest.cs
+++ b/src/DeepNestLib/SvgNest.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using ClipperLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using ClipperLib;
 
 namespace DeepNestLib
 {
@@ -26,10 +26,10 @@ namespace DeepNestLib
         {
             List<InrangeItem> inrange = new List<InrangeItem>();
             // find closest points within 2 offset deltas
-            for (var j = 0; j < simple.length; j++)
+            for (int j = 0; j < simple.length; j++)
             {
-                var s = simple[j];
-                var d2 = (o.x - s.x) * (o.x - s.x) + (o.y - s.y) * (o.y - s.y);
+                SvgPoint s = simple[j];
+                double d2 = (o.x - s.x) * (o.x - s.x) + (o.y - s.y) * (o.y - s.y);
                 if (d2 < tol * tol)
                 {
                     inrange.Add(new InrangeItem() { point = s, distance = d2 });
@@ -39,7 +39,7 @@ namespace DeepNestLib
             SvgPoint target = null;
             if (inrange.Count > 0)
             {
-                var filtered = inrange.Where((p) =>
+                List<InrangeItem> filtered = inrange.Where((p) =>
                 {
                     return p.point.exact;
                 }).ToList();
@@ -60,8 +60,8 @@ namespace DeepNestLib
                 double? mind = null;
                 for (int j = 0; j < simple.length; j++)
                 {
-                    var s = simple[j];
-                    var d2 = (o.x - s.x) * (o.x - s.x) + (o.y - s.y) * (o.y - s.y);
+                    SvgPoint s = simple[j];
+                    double d2 = (o.x - s.x) * (o.x - s.x) + (o.y - s.y) * (o.y - s.y);
                     if (mind == null || d2 < mind)
                     {
                         target = s;
@@ -78,8 +78,8 @@ namespace DeepNestLib
 
         public static NFP clone(NFP p)
         {
-            var newp = new NFP();
-            for (var i = 0; i < p.length; i++)
+            NFP newp = new NFP();
+            for (int i = 0; i < p.length; i++)
             {
                 newp.AddPoint(new SvgPoint(
 
@@ -97,8 +97,8 @@ namespace DeepNestLib
         {
             // scaling is deliberately coarse to filter out points that lie *on* the polygon
 
-            var p = svgToClipper2(polygon, 1000);
-            var pt = new ClipperLib.IntPoint(1000 * point.x, 1000 * point.y);
+            IntPoint[] p = svgToClipper2(polygon, 1000);
+            IntPoint pt = new ClipperLib.IntPoint(1000 * point.x, 1000 * point.y);
 
             return ClipperLib.Clipper.PointInPolygon(pt, p.ToList()) > 0;
         }
@@ -107,9 +107,9 @@ namespace DeepNestLib
         public static bool exterior(NFP simple, NFP complex, bool inside)
         {
             // find all protruding vertices
-            for (var i = 0; i < complex.length; i++)
+            for (int i = 0; i < complex.length; i++)
             {
-                var v = complex[i];
+                SvgPoint v = complex[i];
                 if (!inside && !pointInPolygon(v, simple) && find(v, simple) == null)
                 {
                     return true;
@@ -124,10 +124,10 @@ namespace DeepNestLib
 
         public static NFP simplifyFunction(NFP polygon, bool inside)
         {
-            var tolerance = 4 * Config.CurveTolerance;
+            double tolerance = 4 * Config.CurveTolerance;
 
             // give special treatment to line segments above this length (squared)
-            var fixedTolerance = 40 * Config.CurveTolerance * 40 * Config.CurveTolerance;
+            double fixedTolerance = 40 * Config.CurveTolerance * 40 * Config.CurveTolerance;
             int i, j;
 
 
@@ -141,7 +141,7 @@ namespace DeepNestLib
 				}
 			
 				return hull.getHull();*/
-                var hull = Background.getHull(polygon);
+                NFP hull = NestingService.getHull(polygon);
                 if (hull != null)
                 {
                     return hull;
@@ -152,7 +152,7 @@ namespace DeepNestLib
                 }
             }
 
-            var cleaned = cleanPolygon2(polygon);
+            NFP cleaned = cleanPolygon2(polygon);
             if (cleaned != null && cleaned.length > 1)
             {
                 polygon = cleaned;
@@ -162,16 +162,16 @@ namespace DeepNestLib
                 return polygon;
             }
             // polygon to polyline
-            var copy = polygon.slice(0);
+            NFP copy = polygon.slice(0);
             copy.push(copy[0]);
             // mark all segments greater than ~0.25 in to be kept
             // the PD simplification algo doesn't care about the accuracy of long lines, only the absolute distance of each point
             // we care a great deal
             for (i = 0; i < copy.length - 1; i++)
             {
-                var p1 = copy[i];
-                var p2 = copy[i + 1];
-                var sqd = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
+                SvgPoint p1 = copy[i];
+                SvgPoint p2 = copy[i + 1];
+                double sqd = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
                 if (sqd > fixedTolerance)
                 {
                     p1.marked = true;
@@ -179,7 +179,7 @@ namespace DeepNestLib
                 }
             }
 
-            var simple = Simplify.simplify(copy, tolerance, true);
+            NFP simple = Simplify.simplify(copy, tolerance, true);
             // now a polygon again
             //simple.pop();
             simple.Points = simple.Points.Take(simple.Points.Count() - 1).ToArray();
@@ -195,14 +195,14 @@ namespace DeepNestLib
 
 
 
-            var offsets = polygonOffsetDeepNest(simple, inside ? -tolerance : tolerance);
+            NFP[] offsets = polygonOffsetDeepNest(simple, inside ? -tolerance : tolerance);
 
             NFP offset = null;
             double offsetArea = 0;
             List<NFP> holes = new List<NFP>();
             for (i = 0; i < offsets.Length; i++)
             {
-                var area = GeometryUtil.polygonArea(offsets[i]);
+                double area = GeometryUtil.polygonArea(offsets[i]);
                 if (offset == null || area < offsetArea)
                 {
                     offset = offsets[i];
@@ -217,12 +217,12 @@ namespace DeepNestLib
             // mark any points that are exact
             for (i = 0; i < simple.length; i++)
             {
-                var seg = new NFP();
+                NFP seg = new NFP();
                 seg.AddPoint(simple[i]);
                 seg.AddPoint(simple[i + 1 == simple.length ? 0 : i + 1]);
 
-                var index1 = find(seg[0], polygon);
-                var index2 = find(seg[1], polygon);
+                int? index1 = find(seg[0], polygon);
+                int? index2 = find(seg[1], polygon);
 
                 if (index1 + 1 == index2 || index2 + 1 == index1 || (index1 == 0 && index2 == polygon.length - 1) || (index2 == 0 && index1 == polygon.length - 1))
                 {
@@ -230,14 +230,14 @@ namespace DeepNestLib
                     seg[1].exact = true;
                 }
             }
-            var numshells = 4;
+            int numshells = 4;
             NFP[] shells = new NFP[numshells];
 
             for (j = 1; j < numshells; j++)
             {
-                var delta = j * (tolerance / numshells);
+                double delta = j * (tolerance / numshells);
                 delta = inside ? -delta : delta;
-                var shell = polygonOffsetDeepNest(simple, delta);
+                NFP[] shell = polygonOffsetDeepNest(simple, delta);
                 if (shell.Count() > 0)
                 {
                     shells[j] = shell.First();
@@ -255,11 +255,11 @@ namespace DeepNestLib
             // selective reversal of offset
             for (i = 0; i < offset.length; i++)
             {
-                var o = offset[i];
-                var target = getTarget(o, simple, 2 * tolerance);
+                SvgPoint o = offset[i];
+                SvgPoint target = getTarget(o, simple, 2 * tolerance);
 
                 // reverse point offset and try to find exterior points
-                var test = clone(offset);
+                NFP test = clone(offset);
                 test.Points[i] = new SvgPoint(target.x, target.y);
 
                 if (!exterior(test, polygon, inside))
@@ -274,8 +274,8 @@ namespace DeepNestLib
                     {
                         if (shells[j] != null)
                         {
-                            var shell = shells[j];
-                            var delta = j * (tolerance / numshells);
+                            NFP shell = shells[j];
+                            double delta = j * (tolerance / numshells);
                             target = getTarget(o, shell, 2 * delta);
                             test = clone(offset);
                             test.Points[i] = new SvgPoint(target.x, target.y);
@@ -292,10 +292,10 @@ namespace DeepNestLib
 
             for (i = 0; i < offset.length; i++)
             {
-                var p1 = offset[i];
-                var p2 = offset[i + 1 == offset.length ? 0 : i + 1];
+                SvgPoint p1 = offset[i];
+                SvgPoint p2 = offset[i + 1 == offset.length ? 0 : i + 1];
 
-                var sqd = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
+                double sqd = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
 
                 if (sqd < fixedTolerance)
                 {
@@ -303,10 +303,10 @@ namespace DeepNestLib
                 }
                 for (j = 0; j < simple.length; j++)
                 {
-                    var s1 = simple[j];
-                    var s2 = simple[j + 1 == simple.length ? 0 : j + 1];
+                    SvgPoint s1 = simple[j];
+                    SvgPoint s2 = simple[j + 1 == simple.length ? 0 : j + 1];
 
-                    var sqds = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
+                    double sqds = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
 
                     if (sqds < fixedTolerance)
                     {
@@ -329,11 +329,11 @@ namespace DeepNestLib
 
             //if(straightened){
 
-            var Ac = _Clipper.ScaleUpPaths(offset, 10000000);
-            var Bc = _Clipper.ScaleUpPaths(polygon, 10000000);
+            IntPoint[] Ac = _Clipper.ScaleUpPaths(offset, 10000000);
+            IntPoint[] Bc = _Clipper.ScaleUpPaths(polygon, 10000000);
 
-            var combined = new List<List<IntPoint>>();
-            var clipper = new ClipperLib.Clipper();
+            List<List<IntPoint>> combined = new List<List<IntPoint>>();
+            Clipper clipper = new ClipperLib.Clipper();
 
             clipper.AddPath(Ac.ToList(), ClipperLib.PolyType.ptSubject, true);
             clipper.AddPath(Bc.ToList(), ClipperLib.PolyType.ptSubject, true);
@@ -344,8 +344,8 @@ namespace DeepNestLib
                 double? largestArea = null;
                 for (i = 0; i < combined.Count; i++)
                 {
-                    var n = Background.toNestCoordinates(combined[i].ToArray(), 10000000);
-                    var sarea = -GeometryUtil.polygonArea(n);
+                    NFP n = NestingService.ToNestCoordinates(combined[i].ToArray(), 10000000);
+                    double sarea = -GeometryUtil.polygonArea(n);
                     if (largestArea == null || largestArea < sarea)
                     {
                         offset = n;
@@ -364,9 +364,9 @@ namespace DeepNestLib
             // mark any points that are exact (for line merge detection)
             for (i = 0; i < offset.length; i++)
             {
-                var seg = new SvgPoint[] { offset[i], offset[i + 1 == offset.length ? 0 : i + 1] };
-                var index1 = find(seg[0], polygon);
-                var index2 = find(seg[1], polygon);
+                SvgPoint[] seg = new SvgPoint[] { offset[i], offset[i + 1 == offset.length ? 0 : i + 1] };
+                int? index1 = find(seg[0], polygon);
+                int? index2 = find(seg[1], polygon);
                 if (index1 == null)
                 {
                     index1 = 0;
@@ -394,7 +394,7 @@ namespace DeepNestLib
         }
         public static int? find(SvgPoint v, NFP p)
         {
-            for (var i = 0; i < p.length; i++)
+            for (int i = 0; i < p.length; i++)
             {
                 if (GeometryUtil._withinDistance(v, p[i], Config.CurveTolerance / 1000))
                 {
@@ -408,11 +408,11 @@ namespace DeepNestLib
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var simple = t;
+            NFP simple = t;
 
             simple = simplifyFunction(t, (inside == null) ? false : inside.Value);
 
-            var offsetpaths = new NFP[] { simple };
+            NFP[] offsetpaths = new NFP[] { simple };
             if (offset > 0)
             {
                 offsetpaths = polygonOffsetDeepNest(simple, offset);
@@ -438,7 +438,7 @@ namespace DeepNestLib
                     t.children = new List<NFP>();
                 }
 
-                for (var i = 0; i < simple.children.Count; i++)
+                for (int i = 0; i < simple.children.Count; i++)
                 {
                     t.children.Add(simple.children[i]);
                 }
@@ -446,7 +446,7 @@ namespace DeepNestLib
 
             if (t.children != null && t.children.Count > 0)
             {
-                for (var i = 0; i < t.children.Count; i++)
+                for (int i = 0; i < t.children.Count; i++)
                 {
 
                     offsetTree(t.children[i], -offset, config, cancellationToken, (inside == null) ? true : (!inside));
@@ -465,18 +465,18 @@ namespace DeepNestLib
                 return new[] { polygon };
             }
 
-            var p = svgToClipper(polygon).ToList();
+            List<IntPoint> p = svgToClipper(polygon).ToList();
 
-            var miterLimit = 4;
-            var co = new ClipperLib.ClipperOffset(miterLimit, Config.CurveTolerance * Config.ClipperScale);
+            int miterLimit = 4;
+            ClipperOffset co = new ClipperLib.ClipperOffset(miterLimit, Config.CurveTolerance * Config.ClipperScale);
             co.AddPath(p.ToList(), ClipperLib.JoinType.jtMiter, ClipperLib.EndType.etClosedPolygon);
 
-            var newpaths = new List<List<ClipperLib.IntPoint>>();
+            List<List<IntPoint>> newpaths = new List<List<ClipperLib.IntPoint>>();
             co.Execute(ref newpaths, offset * Config.ClipperScale);
 
 
-            var result = new List<NFP>();
-            for (var i = 0; i < newpaths.Count; i++)
+            List<NFP> result = new List<NFP>();
+            for (int i = 0; i < newpaths.Count; i++)
             {
                 result.Add(clipperToSvg(newpaths[i]));
             }
@@ -492,7 +492,7 @@ namespace DeepNestLib
         {
 
 
-            var d = _Clipper.ScaleUpPaths(polygon, scale == null ? Config.ClipperScale : scale.Value);
+            IntPoint[] d = _Clipper.ScaleUpPaths(polygon, scale == null ? Config.ClipperScale : scale.Value);
             return d.ToArray();
 
         }
@@ -503,7 +503,7 @@ namespace DeepNestLib
 
 
 
-            var d = _Clipper.ScaleUpPaths(polygon, Config.ClipperScale);
+            IntPoint[] d = _Clipper.ScaleUpPaths(polygon, Config.ClipperScale);
             return d.ToArray();
 
             return polygon.Points.Select(z => new IntPoint((long)z.x, (long)z.y)).ToArray();
@@ -511,20 +511,20 @@ namespace DeepNestLib
         // returns a less complex polygon that satisfies the curve tolerance
         public static NFP cleanPolygon(NFP polygon)
         {
-            var p = svgToClipper2(polygon);
+            IntPoint[] p = svgToClipper2(polygon);
             // remove self-intersections and find the biggest polygon that's left
-            var simple = ClipperLib.Clipper.SimplifyPolygon(p.ToList(), ClipperLib.PolyFillType.pftNonZero);
+            List<List<IntPoint>> simple = ClipperLib.Clipper.SimplifyPolygon(p.ToList(), ClipperLib.PolyFillType.pftNonZero);
 
             if (simple == null || simple.Count == 0)
             {
                 return null;
             }
 
-            var biggest = simple[0];
-            var biggestarea = Math.Abs(ClipperLib.Clipper.Area(biggest));
-            for (var i = 1; i < simple.Count; i++)
+            List<IntPoint> biggest = simple[0];
+            double biggestarea = Math.Abs(ClipperLib.Clipper.Area(biggest));
+            for (int i = 1; i < simple.Count; i++)
             {
-                var area = Math.Abs(ClipperLib.Clipper.Area(simple[i]));
+                double area = Math.Abs(ClipperLib.Clipper.Area(simple[i]));
                 if (area > biggestarea)
                 {
                     biggest = simple[i];
@@ -533,7 +533,7 @@ namespace DeepNestLib
             }
 
             // clean up singularities, coincident points and edges
-            var clean = ClipperLib.Clipper.CleanPolygon(biggest, 0.01 *
+            List<IntPoint> clean = ClipperLib.Clipper.CleanPolygon(biggest, 0.01 *
                 Config.CurveTolerance * Config.ClipperScale);
 
             if (clean == null || clean.Count == 0)
@@ -546,20 +546,20 @@ namespace DeepNestLib
 
         public static NFP cleanPolygon2(NFP polygon)
         {
-            var p = svgToClipper(polygon);
+            IntPoint[] p = svgToClipper(polygon);
             // remove self-intersections and find the biggest polygon that's left
-            var simple = ClipperLib.Clipper.SimplifyPolygon(p.ToList(), ClipperLib.PolyFillType.pftNonZero);
+            List<List<IntPoint>> simple = ClipperLib.Clipper.SimplifyPolygon(p.ToList(), ClipperLib.PolyFillType.pftNonZero);
 
             if (simple == null || simple.Count == 0)
             {
                 return null;
             }
 
-            var biggest = simple[0];
-            var biggestarea = Math.Abs(ClipperLib.Clipper.Area(biggest));
-            for (var i = 1; i < simple.Count; i++)
+            List<IntPoint> biggest = simple[0];
+            double biggestarea = Math.Abs(ClipperLib.Clipper.Area(biggest));
+            for (int i = 1; i < simple.Count; i++)
             {
-                var area = Math.Abs(ClipperLib.Clipper.Area(simple[i]));
+                double area = Math.Abs(ClipperLib.Clipper.Area(simple[i]));
                 if (area > biggestarea)
                 {
                     biggest = simple[i];
@@ -568,18 +568,18 @@ namespace DeepNestLib
             }
 
             // clean up singularities, coincident points and edges
-            var clean = ClipperLib.Clipper.CleanPolygon(biggest, 0.01 *
+            List<IntPoint> clean = ClipperLib.Clipper.CleanPolygon(biggest, 0.01 *
                 Config.CurveTolerance * Config.ClipperScale);
 
             if (clean == null || clean.Count == 0)
             {
                 return null;
             }
-            var cleaned = clipperToSvg(clean);
+            NFP cleaned = clipperToSvg(clean);
 
             // remove duplicate endpoints
-            var start = cleaned[0];
-            var end = cleaned[cleaned.length - 1];
+            SvgPoint start = cleaned[0];
+            SvgPoint end = cleaned[cleaned.length - 1];
             if (start == end || (GeometryUtil._almostEqual(start.x, end.x)
                 && GeometryUtil._almostEqual(start.y, end.y)))
             {
@@ -594,7 +594,7 @@ namespace DeepNestLib
         {
             List<SvgPoint> ret = new List<SvgPoint>();
 
-            for (var i = 0; i < polygon.Count; i++)
+            for (int i = 0; i < polygon.Count; i++)
             {
                 ret.Add(new SvgPoint(polygon[i].X / Config.ClipperScale, polygon[i].Y / Config.ClipperScale));
             }
@@ -610,13 +610,13 @@ namespace DeepNestLib
 
             // assign a unique id to each leaf
             //var id = idstart || 0;
-            var id = idstart;
+            int id = idstart;
 
             for (i = 0; i < list.Length; i++)
             {
-                var p = list[i];
+                PolygonTreeItem p = list[i];
 
-                var ischild = false;
+                bool ischild = false;
                 for (j = 0; j < list.Length; j++)
                 {
                     if (j == i)
@@ -671,7 +671,7 @@ namespace DeepNestLib
         public static NFP cloneTree(NFP tree)
         {
             NFP newtree = new NFP();
-            foreach (var t in tree.Points)
+            foreach (SvgPoint t in tree.Points)
             {
                 newtree.AddPoint(new SvgPoint(t.x, t.y) { exact = t.exact });
             }
@@ -680,7 +680,7 @@ namespace DeepNestLib
             if (tree.children != null && tree.children.Count > 0)
             {
                 newtree.children = new List<NFP>();
-                foreach (var c in tree.children)
+                foreach (NFP c in tree.children)
                 {
                     newtree.children.Add(cloneTree(c));
                 }
@@ -691,7 +691,7 @@ namespace DeepNestLib
         }
 
 
-        public Background background = new Background();
+        public NestingService background = new NestingService();
 
 
         PopulationItem individual = null;
@@ -733,7 +733,7 @@ namespace DeepNestLib
             if (ga == null)
             {
                 List<NFP> adam = new List<NFP>();
-                var id = 0;
+                int id = 0;
                 for (int i = 0; i < parts.Count(); i++)
                 {
                     if (!parts[i].IsSheet)
@@ -741,7 +741,7 @@ namespace DeepNestLib
 
                         for (int j = 0; j < parts[i].Quanity; j++)
                         {
-                            var poly = cloneTree(parts[i].Polygon); // deep copy
+                            NFP poly = cloneTree(parts[i].Polygon); // deep copy
                             poly.id = id; // id is the unique id of all parts that will be nested, including cloned duplicates
                             poly.source = i; // source is the id of each unique part from the main part list
 
@@ -773,7 +773,7 @@ namespace DeepNestLib
             individual = null;
 
             // check if current generation is finished
-            var finished = true;
+            bool finished = true;
             for (int i = 0; i < ga.population.Count; i++)
             {
                 if (ga.population[i].fitness == null)
@@ -789,7 +789,7 @@ namespace DeepNestLib
                 ga.generation();
             }
 
-            var running = ga.population.Where((p) =>
+            int running = ga.population.Where((p) =>
             {
                 return p.processing != null;
             }).Count();
@@ -798,15 +798,15 @@ namespace DeepNestLib
             List<int> sheetids = new List<int>();
             List<int> sheetsources = new List<int>();
             List<List<NFP>> sheetchildren = new List<List<NFP>>();
-            var sid = 0;
+            int sid = 0;
             for (int i = 0; i < parts.Count(); i++)
             {
                 if (parts[i].IsSheet)
                 {
-                    var poly = parts[i].Polygon;
+                    NFP poly = parts[i].Polygon;
                     for (int j = 0; j < parts[i].Quanity; j++)
                     {
-                        var cln = cloneTree(poly);
+                        NFP cln = cloneTree(poly);
                         cln.id = sid; // id is the unique id of all parts that will be nested, including cloned duplicates
                         cln.source = poly.source; // source is the id of each unique part from the main part list
 
@@ -833,9 +833,9 @@ namespace DeepNestLib
 
                     for (int j = 0; j < ga.population[i].placements.Count; j++)
                     {
-                        var id = ga.population[i].placements[j].id;
-                        var source = ga.population[i].placements[j].source;
-                        var child = ga.population[i].placements[j].children;
+                        int id = ga.population[i].placements[j].id;
+                        int? source = ga.population[i].placements[j].source;
+                        List<NFP> child = ga.population[i].placements[j].children;
                         //ids[j] = id;
                         ids.Add(id);
                         //sources[j] = source;
@@ -876,8 +876,8 @@ namespace DeepNestLib
 
         public static IntPoint[] toClipperCoordinates(NFP polygon)
         {
-            var clone = new List<IntPoint>();
-            for (var i = 0; i < polygon.length; i++)
+            List<IntPoint> clone = new List<IntPoint>();
+            for (int i = 0; i < polygon.length; i++)
             {
                 clone.Add
                     (new IntPoint(
@@ -954,7 +954,11 @@ namespace DeepNestLib
             List<T> ret = new List<T>();
             for (int i = 0; i < p.Length; i++)
             {
-                if (i >= a && i < (a + b)) continue;
+                if (i >= a && i < (a + b))
+                {
+                    continue;
+                }
+
                 ret.Add(p[i]);
             }
             return ret.ToArray();
@@ -965,7 +969,11 @@ namespace DeepNestLib
             List<List<ClipperLib.IntPoint>> ret = new List<List<ClipperLib.IntPoint>>();
             for (int i = a; i < (a + b); i++)
             {
-                if (i >= a && i < (a + b)) continue;
+                if (i >= a && i < (a + b))
+                {
+                    continue;
+                }
+
                 ret.Add(p[i]);
             }
             return ret;
@@ -976,7 +984,11 @@ namespace DeepNestLib
             List<NFP> ret = new List<NFP>();
             for (int i = 0; i < p.Length; i++)
             {
-                if (i >= a && i < (a + b)) continue;
+                if (i >= a && i < (a + b))
+                {
+                    continue;
+                }
+
                 ret.Add(p[i]);
             }
 


### PR DESCRIPTION
### TL;DR

Refactored the Background class by extracting cache-related functionality into separate classes and standardizing method naming conventions from camelCase to PascalCase.

### What changed?

- Created new `ClipCacheItem`, `DbCache`, and `WindowUnk` classes in the `Backgroud` namespace to handle caching functionality
- Renamed multiple methods from camelCase to PascalCase convention (e.g., `shiftPolygon` → `ShiftPolygon`, `cloneNfp` → `CloneNfp`, `placeParts` → `PlaceParts`)
- Moved cache-related logic from inline implementations to dedicated classes with proper encapsulation
- Updated all method calls throughout the codebase to use the new naming convention
- Reorganized using statements and improved code structure consistency

### How to test?

Run existing unit tests to ensure the refactoring didn't break functionality. Test nesting operations to verify that caching mechanisms work correctly with the new class structure. Verify that polygon operations like shifting, cloning, and placement still produce expected results.

### Why make this change?

This refactoring improves code organization by separating concerns into dedicated classes, making the codebase more maintainable. The naming convention changes align with C# standards, improving code readability and consistency. The extracted cache classes provide better encapsulation and make the caching logic more testable and reusable.