### PR TITLE
refactor(deep-nest): fix .sln file using AnyCPU

### DIFF
--- a/src/DeepNest.sln
+++ b/src/DeepNest.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -17,28 +16,28 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Debug|Any CPU.Build.0 = Debug|x64
 		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Debug|x64.ActiveCfg = Debug|x64
 		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Debug|x64.Build.0 = Debug|x64
-		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Release|Any CPU.ActiveCfg = Release|x64
+		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Release|Any CPU.Build.0 = Release|x64
 		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Release|x64.ActiveCfg = Release|x64
 		{9B062971-A88E-4A3D-B3C9-12B78D15FA66}.Release|x64.Build.0 = Release|x64
-		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Debug|Any CPU.Build.0 = Debug|x64
 		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Debug|x64.ActiveCfg = Debug|x64
 		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Debug|x64.Build.0 = Debug|x64
-		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Release|Any CPU.ActiveCfg = Release|x64
+		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Release|Any CPU.Build.0 = Release|x64
 		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Release|x64.ActiveCfg = Release|x64
 		{E09E5402-28CF-4C96-9410-1AF2A44833E0}.Release|x64.Build.0 = Release|x64
-		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Debug|Any CPU.Build.0 = Debug|x64
 		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Debug|x64.ActiveCfg = Debug|x64
 		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Debug|x64.Build.0 = Debug|x64
-		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Release|Any CPU.ActiveCfg = Release|x64
+		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Release|Any CPU.Build.0 = Release|x64
 		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Release|x64.ActiveCfg = Release|x64
 		{32F6DD67-EF43-49E7-A6B3-4786344BAF14}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection


### PR DESCRIPTION
## Fix solution configuration mismatch causing build failures

The `.csproj` files for all three projects (`clipper_library`, `MinkowskiWrapper`, `DeepNestLib`) define `<Platforms>x64</Platforms>`, meaning they only have `Debug|x64` and `Release|x64` build configurations. However, the `.sln` file's `ProjectConfigurationPlatforms` section was mapping `Any CPU` solution configs to `Any CPU` project configs — which don't exist.

This caused VS to skip all three projects on build/clean with no useful error, and the Configuration Manager showed warnings about missing project configurations.

### What changed

Updated the project configuration mappings in `DeepNest.sln` so that `Any CPU` solution configurations map to `x64` project configurations (e.g. `Debug|Any CPU.ActiveCfg = Debug|x64`). The `x64` solution config mappings were already correct.

No changes to `.csproj` files or build output.