### PR TITLE
feat(nesting): Add rotation constraint to NFP.

### DIFF
--- a/src/DeepNestLib/DeepNestLib.csproj
+++ b/src/DeepNestLib/DeepNestLib.csproj
@@ -9,7 +9,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>DeepNest</PackageId>
-        <Version>1.2.1</Version>
+        <Version>1.3.0</Version>
         <Authors>Rafael del Molino</Authors>
         <Company>Rafael del Molino</Company>
         <Product>DeepNestLib</Product>

--- a/src/DeepNestLib/GeneticAlgorithm.cs
+++ b/src/DeepNestLib/GeneticAlgorithm.cs
@@ -140,7 +140,7 @@ namespace DeepNestLib
 
             for (i = 0; i < female.placements.Count; i++)
             {
-                if (!gene1.Any(z => z.id == female.placements[i].id))
+                if (!gene1.Any(z => z.Id == female.placements[i].Id))
                 {
                     gene1.Add(female.placements[i]);
                     rot1.Add(female.Rotation[i]);
@@ -149,7 +149,7 @@ namespace DeepNestLib
 
             for (i = 0; i < male.placements.Count; i++)
             {
-                if (!gene2.Any(z => z.id == male.placements[i].id))
+                if (!gene2.Any(z => z.Id == male.placements[i].Id))
                 {
                     gene2.Add(male.placements[i]);
                     rot2.Add(male.Rotation[i]);

--- a/src/DeepNestLib/GeometryUtilities/GeometryUtil.cs
+++ b/src/DeepNestLib/GeometryUtilities/GeometryUtil.cs
@@ -211,7 +211,7 @@ namespace DeepNestLib
 
             for (int i = 0; i < nfp.Length; i++)
             {
-                for (int j = 0; j < nfp[i].length; j++)
+                for (int j = 0; j < nfp[i].Length; j++)
                 {
                     if (AlmostEqual(p.x, nfp[i][j].x) && AlmostEqual(p.y, nfp[i][j].y))
                     {
@@ -350,18 +350,18 @@ namespace DeepNestLib
             double Aoffsetx = A.offsetx ?? 0;
             double Aoffsety = A.offsety ?? 0;
 
-            A = A.slice(0);
-            B = B.slice(0);
+            A = A.Slice(0);
+            B = B.Slice(0);
 
             // close the loop for polygons
-            if (A[0] != A[A.length - 1])
+            if (A[0] != A[A.Length - 1])
             {
-                A.push(A[0]);
+                A.Push(A[0]);
             }
 
-            if (B[0] != B[B.length - 1])
+            if (B[0] != B[B.Length - 1])
             {
-                B.push(B[0]);
+                B.Push(B[0]);
             }
 
             NFP edgeA = A;
@@ -372,12 +372,12 @@ namespace DeepNestLib
             double? d;
 
 
-            for (int i = 0; i < edgeB.length; i++)
+            for (int i = 0; i < edgeB.Length; i++)
             {
                 // the shortest/most negative projection of B onto A
                 double? minprojection = null;
                 SvgPoint minp = null;
-                for (int j = 0; j < edgeA.length - 1; j++)
+                for (int j = 0; j < edgeA.Length - 1; j++)
                 {
                     p = new SvgPoint(edgeB[i].x + Boffsetx, edgeB[i].y + Boffsety);
                     s1 = new SvgPoint(edgeA[j].x + Aoffsetx, edgeA[j].y + Aoffsety);
@@ -476,43 +476,43 @@ namespace DeepNestLib
             double Boffsetx = B.offsetx ?? 0;
             double Boffsety = B.offsety ?? 0;
 
-            A = A.slice(0);
-            B = B.slice(0);
+            A = A.Slice(0);
+            B = B.Slice(0);
 
-            for (int i = 0; i < A.length - 1; i++)
+            for (int i = 0; i < A.Length - 1; i++)
             {
-                for (int j = 0; j < B.length - 1; j++)
+                for (int j = 0; j < B.Length - 1; j++)
                 {
                     SvgPoint a1 = new SvgPoint(A[i].x + Aoffsetx, A[i].y + Aoffsety);
                     SvgPoint a2 = new SvgPoint(A[i + 1].x + Aoffsetx, A[i + 1].y + Aoffsety);
                     SvgPoint b1 = new SvgPoint(B[j].x + Boffsetx, B[j].y + Boffsety);
                     SvgPoint b2 = new SvgPoint(B[j + 1].x + Boffsetx, B[j + 1].y + Boffsety);
 
-                    int prevbindex = (j == 0) ? B.length - 1 : j - 1;
-                    int prevaindex = (i == 0) ? A.length - 1 : i - 1;
-                    int nextbindex = (j + 1 == B.length - 1) ? 0 : j + 2;
-                    int nextaindex = (i + 1 == A.length - 1) ? 0 : i + 2;
+                    int prevbindex = (j == 0) ? B.Length - 1 : j - 1;
+                    int prevaindex = (i == 0) ? A.Length - 1 : i - 1;
+                    int nextbindex = (j + 1 == B.Length - 1) ? 0 : j + 2;
+                    int nextaindex = (i + 1 == A.Length - 1) ? 0 : i + 2;
 
                     // go even further back if we happen to hit on a loop end point
                     if (B[prevbindex] == B[j] || (AlmostEqual(B[prevbindex].x, B[j].x) && AlmostEqual(B[prevbindex].y, B[j].y)))
                     {
-                        prevbindex = (prevbindex == 0) ? B.length - 1 : prevbindex - 1;
+                        prevbindex = (prevbindex == 0) ? B.Length - 1 : prevbindex - 1;
                     }
 
                     if (A[prevaindex] == A[i] || (AlmostEqual(A[prevaindex].x, A[i].x) && AlmostEqual(A[prevaindex].y, A[i].y)))
                     {
-                        prevaindex = (prevaindex == 0) ? A.length - 1 : prevaindex - 1;
+                        prevaindex = (prevaindex == 0) ? A.Length - 1 : prevaindex - 1;
                     }
 
                     // go even further forward if we happen to hit on a loop end point
                     if (B[nextbindex] == B[j + 1] || (AlmostEqual(B[nextbindex].x, B[j + 1].x) && AlmostEqual(B[nextbindex].y, B[j + 1].y)))
                     {
-                        nextbindex = (nextbindex == B.length - 1) ? 0 : nextbindex + 1;
+                        nextbindex = (nextbindex == B.Length - 1) ? 0 : nextbindex + 1;
                     }
 
                     if (A[nextaindex] == A[i + 1] || (AlmostEqual(A[nextaindex].x, A[i + 1].x) && AlmostEqual(A[nextaindex].y, A[i + 1].y)))
                     {
-                        nextaindex = (nextaindex == A.length - 1) ? 0 : nextaindex + 1;
+                        nextaindex = (nextaindex == A.Length - 1) ? 0 : nextaindex + 1;
                     }
 
                     SvgPoint a0 = new SvgPoint(A[prevaindex].x + Aoffsetx, A[prevaindex].y + Aoffsety);
@@ -657,32 +657,32 @@ namespace DeepNestLib
         public static SvgPoint SearchStartPoint(NFP A, NFP B, bool inside, NFP[] NFP = null)
         {
             // clone arrays
-            A = A.slice(0);
-            B = B.slice(0);
+            A = A.Slice(0);
+            B = B.Slice(0);
 
             // close the loop for polygons
-            if (A[0] != A[A.length - 1])
+            if (A[0] != A[A.Length - 1])
             {
-                A.push(A[0]);
+                A.Push(A[0]);
             }
 
-            if (B[0] != B[B.length - 1])
+            if (B[0] != B[B.Length - 1])
             {
-                B.push(B[0]);
+                B.Push(B[0]);
             }
 
-            for (int i = 0; i < A.length - 1; i++)
+            for (int i = 0; i < A.Length - 1; i++)
             {
                 if (!A[i].marked)
                 {
                     A[i].marked = true;
-                    for (int j = 0; j < B.length; j++)
+                    for (int j = 0; j < B.Length; j++)
                     {
                         B.offsetx = A[i].x - B[j].x;
                         B.offsety = A[i].y - B[j].y;
 
                         bool? Binside = null;
-                        for (int k = 0; k < B.length; k++)
+                        for (int k = 0; k < B.Length; k++)
                         {
                             bool? inpoly = PointInPolygon(new SvgPoint(B[k].x + B.offsetx.Value,
                                 B[k].y + B.offsety.Value), A);
@@ -754,7 +754,7 @@ namespace DeepNestLib
                         B.offsetx += vx;
                         B.offsety += vy;
 
-                        for (int k = 0; k < B.length; k++)
+                        for (int k = 0; k < B.Length; k++)
                         {
                             bool? inpoly = PointInPolygon(
                                 new SvgPoint(
@@ -987,18 +987,18 @@ namespace DeepNestLib
             Boffsetx = B.offsetx ?? 0;
             Boffsety = B.offsety ?? 0;
 
-            A = A.slice(0);
-            B = B.slice(0);
+            A = A.Slice(0);
+            B = B.Slice(0);
 
             // close the loop for polygons
-            if (A[0] != A[A.length - 1])
+            if (A[0] != A[A.Length - 1])
             {
-                A.push(A[0]);
+                A.Push(A[0]);
             }
 
-            if (B[0] != B[B.length - 1])
+            if (B[0] != B[B.Length - 1])
             {
-                B.push(B[0]);
+                B.Push(B[0]);
             }
 
             NFP edgeA = A;
@@ -1018,10 +1018,10 @@ namespace DeepNestLib
 
             SvgPoint reverse = new SvgPoint(-dir.x, -dir.y);
 
-            for (int i = 0; i < edgeB.length - 1; i++)
+            for (int i = 0; i < edgeB.Length - 1; i++)
             {
                 //var mind = null;
-                for (int j = 0; j < edgeA.length - 1; j++)
+                for (int j = 0; j < edgeA.Length - 1; j++)
                 {
                     A1 = new SvgPoint(
                          edgeA[j].x + Aoffsetx, edgeA[j].y + Aoffsety
@@ -1056,7 +1056,7 @@ namespace DeepNestLib
         // if the searchEdges flag is set, all edges of A are explored for NFPs - multiple 
         public static NFP[] NoFitPolygon(NFP A, NFP B, bool inside, bool searchEdges)
         {
-            if (A == null || A.length < 3 || B == null || B.length < 3)
+            if (A == null || A.Length < 3 || B == null || B.Length < 3)
             {
                 return null;
             }
@@ -1072,7 +1072,7 @@ namespace DeepNestLib
             double maxB = B[0].y;
             int maxBindex = 0;
 
-            for (i = 1; i < A.length; i++)
+            for (i = 1; i < A.Length; i++)
             {
                 A[i].marked = false;
                 if (A[i].y < minA)
@@ -1082,7 +1082,7 @@ namespace DeepNestLib
                 }
             }
 
-            for (i = 1; i < B.length; i++)
+            for (i = 1; i < B.Length; i++)
             {
                 B[i].marked = false;
                 if (B[i].y > maxB)
@@ -1120,7 +1120,7 @@ namespace DeepNestLib
 
                 NVector prevvector = null; // keep track of previous vector
                 NFP NFP = new NFP();
-                NFP.push(new SvgPoint(B[0].x + B.offsetx.Value, B[0].y + B.offsety.Value));
+                NFP.Push(new SvgPoint(B[0].x + B.offsetx.Value, B[0].y + B.offsety.Value));
 
                 double referencex = B[0].x + B.offsetx.Value;
                 double referencey = B[0].y + B.offsety.Value;
@@ -1128,16 +1128,16 @@ namespace DeepNestLib
                 double starty = referencey;
                 int counter = 0;
 
-                while (counter < 10 * (A.length + B.length))
+                while (counter < 10 * (A.Length + B.Length))
                 { // sanity check, prevent infinite loop
                     touching = new List<GeometryUtil.TouchingItem>();
                     // find touching vertices/edges
-                    for (i = 0; i < A.length; i++)
+                    for (i = 0; i < A.Length; i++)
                     {
-                        int nexti = (i == A.length - 1) ? 0 : i + 1;
-                        for (j = 0; j < B.length; j++)
+                        int nexti = (i == A.Length - 1) ? 0 : i + 1;
+                        for (j = 0; j < B.Length; j++)
                         {
-                            int nextj = (j == B.length - 1) ? 0 : j + 1;
+                            int nextj = (j == B.Length - 1) ? 0 : j + 1;
                             if (AlmostEqual(A[i].x, B[j].x + B.offsetx) && AlmostEqual(A[i].y, B[j].y + B.offsety))
                             {
                                 touching.Add(new TouchingItem(0, i, j));
@@ -1169,8 +1169,8 @@ namespace DeepNestLib
                         int prevAindex = touching[i].A - 1;
                         int nextAindex = touching[i].A + 1;
 
-                        prevAindex = (prevAindex < 0) ? A.length - 1 : prevAindex; // loop
-                        nextAindex = (nextAindex >= A.length) ? 0 : nextAindex; // loop
+                        prevAindex = (prevAindex < 0) ? A.Length - 1 : prevAindex; // loop
+                        nextAindex = (nextAindex >= A.Length) ? 0 : nextAindex; // loop
 
                         SvgPoint prevA = A[prevAindex];
                         SvgPoint nextA = A[nextAindex];
@@ -1181,8 +1181,8 @@ namespace DeepNestLib
                         int prevBindex = touching[i].B - 1;
                         int nextBindex = touching[i].B + 1;
 
-                        prevBindex = (prevBindex < 0) ? B.length - 1 : prevBindex; // loop
-                        nextBindex = (nextBindex >= B.length) ? 0 : nextBindex; // loop
+                        prevBindex = (prevBindex < 0) ? B.Length - 1 : prevBindex; // loop
+                        nextBindex = (nextBindex >= B.Length) ? 0 : nextBindex; // loop
 
                         SvgPoint prevB = B[prevBindex];
                         SvgPoint nextB = B[nextBindex];
@@ -1338,9 +1338,9 @@ namespace DeepNestLib
 
                     // if A and B start on a touching horizontal line, the end point may not be the start point
                     bool looped = false;
-                    if (NFP.length > 0)
+                    if (NFP.Length > 0)
                     {
-                        for (i = 0; i < NFP.length - 1; i++)
+                        for (i = 0; i < NFP.Length - 1; i++)
                         {
                             if (AlmostEqual(referencex, NFP[i].x) && AlmostEqual(referencey, NFP[i].y))
                             {
@@ -1355,7 +1355,7 @@ namespace DeepNestLib
                         break;
                     }
 
-                    NFP.push(new SvgPoint(
+                    NFP.Push(new SvgPoint(
                          referencex, referencey
                     ));
 
@@ -1365,7 +1365,7 @@ namespace DeepNestLib
                     counter++;
                 }
 
-                if (NFP != null && NFP.length > 0)
+                if (NFP != null && NFP.Length > 0)
                 {
                     NFPlist.Add(NFP);
 

--- a/src/DeepNestLib/NFP.cs
+++ b/src/DeepNestLib/NFP.cs
@@ -1,4 +1,5 @@
-﻿using DeepNestLib.Svg;
+﻿using DeepNestLib.Rotation;
+using DeepNestLib.Svg;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,19 +8,30 @@ namespace DeepNestLib
 {
     public class NFP : IStringify
     {
+        public string Name { get; set; }
+        public SvgPoint this[int index] => Points[index];
+        public List<NFP> children = null;
+
+        public double? offsetx;
+        public double? offsety;
+        public int Length => Points?.Length ?? 0;
+        public int? Source { get; set; }
+        public int? Id { get; set; }
+        public float Rotation { get; set; } = 0f;
+        public RotationConstraint RotationConstraint { get; set; } = RotationConstraint.Fixed;
+        public SvgPoint[] Points;
         public bool fitted { get { return sheet != null; } }
         public NFP sheet;
         public override string ToString()
         {
             string str1 = (Points != null) ? Points.Count() + "" : "null";
-            return $"nfp: id: {id}; source: {source}; rotation: {rotation}; points: {str1}";
+            return $"nfp: id: {Id}; source: {Source}; rotation: {Rotation}; points: {str1}";
         }
         public NFP()
         {
-            Points = new SvgPoint[] { };
+            Points = [];
         }
 
-        public string Name { get; set; }
         public void AddPoint(SvgPoint point)
         {
             List<SvgPoint> list = Points.ToList();
@@ -31,7 +43,7 @@ namespace DeepNestLib
         public bool isBin;
 
         #endregion
-        public void reverse()
+        public void Reverse()
         {
             Points = Points.Reverse().ToArray();
         }
@@ -60,68 +72,6 @@ namespace DeepNestLib
             }
         }
 
-        public SvgPoint this[int ind]
-        {
-            get
-            {
-                return Points[ind];
-            }
-        }
-
-        public List<NFP> children;
-
-
-
-
-        public int Length
-        {
-            get
-            {
-                return Points.Length;
-            }
-        }
-
-        //public float? width;
-        //public float? height;
-        public int length
-        {
-            get
-            {
-                return Points.Length;
-            }
-        }
-
-        public int Id;
-        public int id
-        {
-            get
-            {
-                return Id;
-            }
-            set
-            {
-                Id = value;
-            }
-        }
-
-        public double? offsetx;
-        public double? offsety;
-        public int? source = null;
-        public float Rotation;
-
-
-        public float rotation
-        {
-            get
-            {
-                return Rotation;
-            }
-            set
-            {
-                Rotation = value;
-            }
-        }
-        public SvgPoint[] Points;
         public float Area
         {
             get
@@ -145,7 +95,7 @@ namespace DeepNestLib
             }
         }
 
-        internal void push(SvgPoint svgPoint)
+        internal void Push(SvgPoint svgPoint)
         {
             List<SvgPoint> points = new List<SvgPoint>();
             if (Points == null)
@@ -158,11 +108,11 @@ namespace DeepNestLib
 
         }
 
-        public NFP slice(int v)
+        public NFP Slice(int v)
         {
-            var ret = new NFP();
+            NFP ret = new NFP();
             List<SvgPoint> pp = new List<SvgPoint>();
-            for (int i = v; i < length; i++)
+            for (int i = v; i < Length; i++)
             {
                 pp.Add(new SvgPoint(this[i].x, this[i].y));
 

--- a/src/DeepNestLib/NestingContext.cs
+++ b/src/DeepNestLib/NestingContext.cs
@@ -49,18 +49,18 @@ namespace DeepNestLib
 
             for (int i = 0; i < Polygons.Count; i++)
             {
-                Polygons[i].id = i;
+                Polygons[i].Id = i;
             }
             for (int i = 0; i < Sheets.Count; i++)
             {
-                Sheets[i].id = i;
+                Sheets[i].Id = i;
             }
             foreach (NFP item in Polygons)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 NFP clone = new NFP();
-                clone.id = item.id;
-                clone.source = item.source;
+                clone.Id = item.Id;
+                clone.Source = item.Source;
                 clone.Points = item.Points.Select(z => new SvgPoint(z.x, z.y) { exact = z.exact }).ToArray();
                 if (item.children != null)
                 {
@@ -69,8 +69,8 @@ namespace DeepNestLib
                     {
                         clone.children.Add(new NFP());
                         NFP l = clone.children.Last();
-                        l.id = citem.id;
-                        l.source = citem.source;
+                        l.Id = citem.Id;
+                        l.Source = citem.Source;
                         l.Points = citem.Points.Select(z => new SvgPoint(z.x, z.y) { exact = z.exact }).ToArray();
                     }
                 }
@@ -82,8 +82,8 @@ namespace DeepNestLib
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 NFP clone = new NFP();
-                clone.id = item.id;
-                clone.source = item.source;
+                clone.Id = item.Id;
+                clone.Source = item.Source;
                 clone.Points = item.Points.Select(z => new SvgPoint(z.x, z.y) { exact = z.exact }).ToArray();
                 if (item.children != null)
                 {
@@ -93,8 +93,8 @@ namespace DeepNestLib
                         cancellationToken.ThrowIfCancellationRequested();
                         clone.children.Add(new NFP());
                         NFP l = clone.children.Last();
-                        l.id = citem.id;
-                        l.source = citem.source;
+                        l.Id = citem.Id;
+                        l.Source = citem.Source;
                         l.Points = citem.Points.Select(z => new SvgPoint(z.x, z.y) { exact = z.exact }).ToArray();
                     }
                 }
@@ -103,7 +103,7 @@ namespace DeepNestLib
 
             if (offsetTreePhase)
             {
-                IGrouping<int?, NFP>[] grps = lpoly.GroupBy(z => z.source).ToArray();
+                IGrouping<int?, NFP>[] grps = lpoly.GroupBy(z => z.Source).ToArray();
                 if (NestingService.UseParallel)
                 {
                     Parallel.ForEach(grps, (item) =>
@@ -144,14 +144,14 @@ namespace DeepNestLib
 
 
             List<NestItem> partsLocal = new List<NestItem>();
-            IEnumerable<NestItem> p1 = lpoly.GroupBy(z => z.source).Select(z => new NestItem()
+            IEnumerable<NestItem> p1 = lpoly.GroupBy(z => z.Source).Select(z => new NestItem()
             {
                 Polygon = z.First(),
                 IsSheet = false,
                 Quanity = z.Count()
             });
 
-            IEnumerable<NestItem> p2 = lsheets.GroupBy(z => z.source).Select(z => new NestItem()
+            IEnumerable<NestItem> p2 = lsheets.GroupBy(z => z.Source).Select(z => new NestItem()
             {
                 Polygon = z.First(),
                 IsSheet = true,
@@ -164,7 +164,7 @@ namespace DeepNestLib
             int srcc = 0;
             foreach (NestItem item in partsLocal)
             {
-                item.Polygon.source = srcc++;
+                item.Polygon.Source = srcc++;
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -210,7 +210,7 @@ namespace DeepNestLib
                         sheetsIds.Add(sheetid);
                     }
 
-                    NFP sheet = Sheets.First(z => z.id == sheetid);
+                    NFP sheet = Sheets.First(z => z.Id == sheetid);
                     totalSheetsArea += GeometryUtil.PolygonArea(sheet);
 
                     foreach (PlacementItem ssitem in zitem.sheetplacements)
@@ -218,18 +218,18 @@ namespace DeepNestLib
                         cancellationToken.ThrowIfCancellationRequested();
 
                         PlacedPartsCount++;
-                        NFP poly = Polygons.First(z => z.id == ssitem.id);
+                        NFP poly = Polygons.First(z => z.Id == ssitem.id);
                         totalPartsArea += GeometryUtil.PolygonArea(poly);
                         placed.Add(poly);
                         poly.sheet = sheet;
                         poly.x = ssitem.x + sheet.x;
                         poly.y = ssitem.y + sheet.y;
-                        poly.rotation = ssitem.rotation;
+                        poly.Rotation = ssitem.rotation;
                     }
                 }
             }
 
-            NFP[] emptySheets = Sheets.Where(z => !sheetsIds.Contains(z.id)).ToArray();
+            NFP[] emptySheets = Sheets.Where(z => !sheetsIds.Contains(z.Id)).ToArray();
 
             MaterialUtilization = Math.Abs(totalPartsArea / totalSheetsArea);
 
@@ -271,7 +271,7 @@ namespace DeepNestLib
             tt.Name = "sheet" + (Sheets.Count + 1);
             Sheets.Add(tt);
 
-            tt.source = src;
+            tt.Source = src;
             tt.Height = h;
             tt.Width = w;
             tt.Rebuild();
@@ -352,7 +352,7 @@ namespace DeepNestLib
                     po.children.Add(r);
                 }
 
-                po.source = src;
+                po.Source = src;
                 Polygons.Add(po);
             }
             return po;
@@ -361,7 +361,7 @@ namespace DeepNestLib
         {
             if (Polygons.Any())
             {
-                return Polygons.Max(z => z.source.Value) + 1;
+                return Polygons.Max(z => z.Source.Value) + 1;
             }
             return 0;
         }
@@ -369,7 +369,7 @@ namespace DeepNestLib
         {
             if (Sheets.Any())
             {
-                return Sheets.Max(z => z.source.Value) + 1;
+                return Sheets.Max(z => z.Source.Value) + 1;
             }
             return 0;
         }
@@ -380,7 +380,7 @@ namespace DeepNestLib
             NFP pl = new NFP();
 
             Polygons.Add(pl);
-            pl.source = src;
+            pl.Source = src;
             pl.Points = new SvgPoint[] { };
             pl.AddPoint(new SvgPoint(xx, yy));
             pl.AddPoint(new SvgPoint(xx + ww, yy));

--- a/src/DeepNestLib/NestingService.cs
+++ b/src/DeepNestLib/NestingService.cs
@@ -2,6 +2,7 @@
 using DeepNestLib.Background;
 using DeepNestLib.GeometryUtilities;
 using DeepNestLib.NoFitPolygon;
+using DeepNestLib.Rotation;
 using DeepNestLib.Sheets;
 using DeepNestLib.Svg;
 using Minkowski;
@@ -27,7 +28,7 @@ namespace DeepNestLib
         public static NFP ShiftPolygon(NFP p, PlacementItem shift)
         {
             NFP shifted = new NFP();
-            for (int i = 0; i < p.length; i++)
+            for (int i = 0; i < p.Length; i++)
             {
                 shifted.AddPoint(new SvgPoint(p[i].x + shift.x, p[i].y + shift.y) { exact = p[i].exact });
             }
@@ -70,7 +71,7 @@ namespace DeepNestLib
         public static NFP Clone(NFP nfp)
         {
             NFP newnfp = new();
-            for (int i = 0; i < nfp.length; i++)
+            for (int i = 0; i < nfp.Length; i++)
             {
                 newnfp.AddPoint(new SvgPoint(nfp[i].x, nfp[i].y));
             }
@@ -82,7 +83,7 @@ namespace DeepNestLib
                 {
                     NFP child = nfp.children[i];
                     NFP newchild = new NFP();
-                    for (int j = 0; j < child.length; j++)
+                    for (int j = 0; j < child.Length; j++)
                     {
                         newchild.AddPoint(new SvgPoint(child[j].x, child[j].y));
                     }
@@ -99,7 +100,7 @@ namespace DeepNestLib
         public static ConcurrentDictionary<string, NFP[]> cacheProcess = new ConcurrentDictionary<string, NFP[]>();
         public static NFP[] Process2(NFP A, NFP B, int type)
         {
-            string key = A.source + ";" + B.source + ";" + A.rotation + ";" + B.rotation;
+            string key = A.Source + ";" + B.Source + ";" + A.Rotation + ";" + B.Rotation;
             bool cacheAllow = type != 1;
             if (cacheAllow && cacheProcess.TryGetValue(key, out NFP[]? cachedValue))
             {
@@ -247,30 +248,30 @@ namespace DeepNestLib
             bounds.y -= 0.5 * (bounds.height - (bounds.height / 1.1));
 
             NFP frame = new NFP();
-            frame.push(new SvgPoint(bounds.x, bounds.y));
-            frame.push(new SvgPoint(bounds.x + bounds.width, bounds.y));
-            frame.push(new SvgPoint(bounds.x + bounds.width, bounds.y + bounds.height));
-            frame.push(new SvgPoint(bounds.x, bounds.y + bounds.height));
+            frame.Push(new SvgPoint(bounds.x, bounds.y));
+            frame.Push(new SvgPoint(bounds.x + bounds.width, bounds.y));
+            frame.Push(new SvgPoint(bounds.x + bounds.width, bounds.y + bounds.height));
+            frame.Push(new SvgPoint(bounds.x, bounds.y + bounds.height));
 
 
             frame.children = new List<NFP>() { (NFP)A };
-            frame.source = A.source;
-            frame.rotation = 0;
+            frame.Source = A.Source;
+            frame.Rotation = 0;
 
             return frame;
         }
 
         public static NFP[] GetInnerNfp(NFP A, NFP B, int type, SvgNestConfig config)
         {
-            if (A.source != null && B.source != null)
+            if (A.Source != null && B.Source != null)
             {
 
                 DbCacheKey key = new DbCacheKey()
                 {
-                    A = A.source.Value,
-                    B = B.source.Value,
+                    A = A.Source.Value,
+                    B = B.Source.Value,
                     ARotation = 0,
-                    BRotation = B.rotation,
+                    BRotation = B.Rotation,
                     //Inside =true??
                 };
                 //var doc = window.db.find({ A: A.source, B: B.source, Arotation: 0, Brotation: B.rotation }, true);
@@ -332,15 +333,15 @@ namespace DeepNestLib
                 f.Add(ToNestCoordinates(finalNfp[i].ToArray(), config.ClipperScale));
             }
 
-            if (A.source != null && B.source != null)
+            if (A.Source != null && B.Source != null)
             {
                 // insert into db
                 DbCacheKey doc = new DbCacheKey()
                 {
-                    A = A.source.Value,
-                    B = B.source.Value,
+                    A = A.Source.Value,
+                    B = B.Source.Value,
                     ARotation = 0,
-                    BRotation = B.rotation,
+                    BRotation = B.Rotation,
                     nfp = f.ToArray()
 
 
@@ -356,8 +357,8 @@ namespace DeepNestLib
             NFP rotated = new NFP();
 
             double angle = degrees * Math.PI / 180;
-            List<SvgPoint> pp = new List<SvgPoint>(polygon.length);
-            for (int i = 0; i < polygon.length; i++)
+            List<SvgPoint> pp = new List<SvgPoint>(polygon.Length);
+            for (int i = 0; i < polygon.Length; i++)
             {
                 double x = polygon[i].x;
                 double y = polygon[i].y;
@@ -390,44 +391,43 @@ namespace DeepNestLib
             int i, j, k, m, n;
             double totalsheetarea = 0;
 
-            NFP part = null;
             // total length of merged lines
             double totalMerged = 0;
 
             // rotate paths by given rotation
-            List<NFP> rotated = new List<NFP>();
+            List<NFP> rotatedParts = [];
             for (i = 0; i < parts.Length; i++)
             {
-                NFP r = RotatePolygon(parts[i], parts[i].rotation);
-                r.Rotation = parts[i].rotation;
-                r.source = parts[i].source;
-                r.Id = parts[i].Id;
-                rotated.Add(r);
+                NFP originalPart = parts[i];
+                NFP rotatedPart = RotatePolygon(originalPart, originalPart.Rotation);
+                rotatedPart.Rotation = originalPart.Rotation;
+                rotatedPart.Source = originalPart.Source;
+                rotatedPart.Id = originalPart.Id;
+                rotatedPart.RotationConstraint = originalPart.RotationConstraint;
+                rotatedParts.Add(rotatedPart);
             }
 
-            parts = rotated.ToArray();
+            parts = rotatedParts.ToArray();
 
-            List<SheetPlacementItem> allplacements = new List<SheetPlacementItem>();
+            List<SheetPlacementItem> allplacements = [];
 
             double fitness = 0;
             NFP nfp;
             double sheetarea = -1;
             int totalPlaced = 0;
-            int totalParts = parts.Count();
+            int totalParts = parts.Length;
+
             while (parts.Length > 0)
             {
                 cancellationToken.ThrowIfCancellationRequested(); // Check for cancellation at the start of each sheet placement
 
-                List<NFP> placed = new List<NFP>();
+                List<NFP> placed = [];
+                List<PlacementItem> placements = [];
 
-                List<PlacementItem> placements = new List<PlacementItem>();
-
-                // open a new sheet
                 NFP sheet = sheets.First();
                 sheets = sheets.Skip(1).ToArray();
                 sheetarea = Math.Abs(GeometryUtil.PolygonArea(sheet));
                 totalsheetarea += sheetarea;
-
                 fitness += sheetarea; // add 1 for each new sheet opened (lower fitness is better)
 
                 string clipkey = "";
@@ -439,49 +439,38 @@ namespace DeepNestLib
                 double? minwidth = null;
                 PlacementItem position = null;
                 double? minarea = null;
+
                 for (i = 0; i < parts.Length; i++)
                 {
                     cancellationToken.ThrowIfCancellationRequested(); // Check for cancellation for each part
                     float prog = 0.66f + 0.34f * (totalPlaced / (float)totalParts);
                     DisplayProgress(prog);
 
-                    part = parts[i];
+                    NFP part = parts[i];
+
                     // inner NFP
                     NFP[] sheetNfp = null;
-                    // try all possible rotations until it fits
-                    // (only do this for the first part of each sheet, to ensure that all parts that can be placed are, even if we have to to open a lot of sheets)
-                    for (j = 0; j < (360f / config.Rotations); j++)
+                    bool canPlace = false;
+
+                    List<float> allowedAngles = RotationHelpers.GetAllowedRotation(part);
+
+                    foreach (float angle in allowedAngles)
                     {
-                        sheetNfp = GetInnerNfp(sheet, part, 0, config);
+                        NFP rotatedPart = RotatePolygon(part, angle);
+                        rotatedPart.Rotation = angle;
+                        rotatedPart.Source = part.Source;
+                        rotatedPart.Id = part.Id;
+                        rotatedPart.RotationConstraint = part.RotationConstraint;
 
-                        if (sheetNfp != null && sheetNfp.Count() > 0)
+                        sheetNfp = GetInnerNfp(sheet, rotatedPart, 0, config);
+                        if (sheetNfp != null && sheetNfp.Length > 0 && sheetNfp[0].Length > 0)
                         {
-                            if (sheetNfp[0].length == 0)
-                            {
-                                throw new ArgumentException();
-                            }
-                            else
-                            {
-                                break;
-                            }
-                        }
-
-                        NFP r = RotatePolygon(part, 360f / config.Rotations);
-                        r.rotation = part.rotation + (360f / config.Rotations);
-                        r.source = part.source;
-                        r.id = part.id;
-
-                        // rotation is not in-place
-                        part = r;
-                        parts[i] = r;
-
-                        if (part.rotation > 360f)
-                        {
-                            part.rotation = part.rotation % 360f;
+                            part = rotatedPart;           // Use this rotation
+                            parts[i] = rotatedPart;       // Update in the array
+                            break;
                         }
                     }
-                    // part unplaceable, skip
-                    if (sheetNfp == null || sheetNfp.Count() == 0)
+                    if (!canPlace || sheetNfp == null || sheetNfp.Length == 0)
                     {
                         continue;
                     }
@@ -493,7 +482,7 @@ namespace DeepNestLib
                         // first placement, put it on the top left corner
                         for (j = 0; j < sheetNfp.Count(); j++)
                         {
-                            for (k = 0; k < sheetNfp[j].length; k++)
+                            for (k = 0; k < sheetNfp[j].Length; k++)
                             {
                                 if (position == null ||
                                     ((sheetNfp[j][k].x - part[0].x) < position.x) ||
@@ -506,9 +495,9 @@ namespace DeepNestLib
                                     {
                                         x = sheetNfp[j][k].x - part[0].x,
                                         y = sheetNfp[j][k].y - part[0].y,
-                                        id = part.id,
-                                        rotation = part.rotation,
-                                        source = part.source.Value
+                                        id = part.Id,
+                                        rotation = part.Rotation,
+                                        source = part.Source.Value
 
                                     };
 
@@ -537,7 +526,7 @@ namespace DeepNestLib
                     error = false;
 
                     // check if stored in clip cache
-                    clipkey = "s:" + part.source + "r:" + part.rotation;
+                    clipkey = "s:" + part.Source + "r:" + part.Rotation;
                     int startindex = 0;
                     if (EnableCaches && clipCache.ContainsKey(clipkey))
                     {
@@ -556,7 +545,7 @@ namespace DeepNestLib
                             break;
                         }
                         // shift to placed location
-                        for (m = 0; m < nfp.length; m++)
+                        for (m = 0; m < nfp.Length; m++)
                         {
                             nfp[m].x += placements[j].x;
                             nfp[m].y += placements[j].y;
@@ -565,7 +554,7 @@ namespace DeepNestLib
                         {
                             for (n = 0; n < nfp.children.Count; n++)
                             {
-                                for (int o = 0; o < nfp.children[n].length; o++)
+                                for (int o = 0; o < nfp.children[n].Length; o++)
                                 {
                                     nfp.children[n][o].x += placements[j].x;
                                     nfp.children[n][o].y += placements[j].y;
@@ -635,7 +624,7 @@ namespace DeepNestLib
                     NFP allpoints = new NFP();
                     for (m = 0; m < placed.Count; m++)
                     {
-                        for (n = 0; n < placed[m].length; n++)
+                        for (n = 0; n < placed[m].Length; n++)
                         {
                             allpoints.AddPoint(
                                 new SvgPoint(
@@ -650,7 +639,7 @@ namespace DeepNestLib
                         allbounds = GeometryUtil.GetPolygonBounds(allpoints);
 
                         NFP partpoints = new NFP();
-                        for (m = 0; m < part.length; m++)
+                        for (m = 0; m < part.Length; m++)
                         {
                             partpoints.AddPoint(new SvgPoint(part[m].x, part[m].y));
                         }
@@ -663,15 +652,15 @@ namespace DeepNestLib
                     for (j = 0; j < finalNfp.Count; j++)
                     {
                         nf = finalNfp[j];
-                        for (k = 0; k < nf.length; k++)
+                        for (k = 0; k < nf.Length; k++)
                         {
                             shiftvector = new PlacementItem()
                             {
-                                id = part.id,
+                                id = part.Id,
                                 x = nf[k].x - part[0].x,
                                 y = nf[k].y - part[0].y,
-                                source = part.source.Value,
-                                rotation = part.rotation
+                                source = part.Source.Value,
+                                rotation = part.Rotation
                             };
                             PolygonBounds rectbounds = null;
                             if (config.PlacementType == PlacementTypeEnum.gravity || config.PlacementType == PlacementTypeEnum.box)
@@ -702,7 +691,7 @@ namespace DeepNestLib
                                 // must be convex hull
                                 NFP localpoints = Clone(allpoints);
 
-                                for (m = 0; m < part.length; m++)
+                                for (m = 0; m < part.Length; m++)
                                 {
                                     localpoints.AddPoint(new SvgPoint(part[m].x + shiftvector.x, part[m].y + shiftvector.y));
                                 }
@@ -787,8 +776,8 @@ namespace DeepNestLib
                 {
                     allplacements.Add(new SheetPlacementItem()
                     {
-                        sheetId = sheet.id,
-                        sheetSource = sheet.source.Value,
+                        sheetId = sheet.Id,
+                        sheetSource = sheet.Source.Value,
                         sheetplacements = placements
                     });
                 }
@@ -866,7 +855,7 @@ namespace DeepNestLib
             {
                 ConcurrentBag<NfpPair> concurrentPairs = new ConcurrentBag<NfpPair>();
 
-                Parallel.For(0, parts.Count, i =>
+                Parallel.For(0, parts.Count, (Action<int>)(i =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     NFP B = parts[i];
@@ -877,17 +866,17 @@ namespace DeepNestLib
                         {
                             A = A,
                             B = B,
-                            ARotation = A.rotation,
-                            BRotation = B.rotation,
-                            Asource = A.source.Value,
-                            Bsource = B.source.Value
+                            ARotation = A.Rotation,
+                            BRotation = B.Rotation,
+                            Asource = A.Source.Value,
+                            Bsource = B.Source.Value
                         };
                         DbCacheKey doc = new DbCacheKey()
                         {
-                            A = A.source.Value,
-                            B = B.source.Value,
-                            ARotation = A.rotation,
-                            BRotation = B.rotation
+                            A = A.Source.Value,
+                            B = B.Source.Value,
+                            ARotation = A.Rotation,
+                            BRotation = B.Rotation
                         };
 
                         if (!window.db.Has(doc))
@@ -895,7 +884,7 @@ namespace DeepNestLib
                             concurrentPairs.Add(key);
                         }
                     }
-                });
+                }));
 
                 pairs = concurrentPairs
                     .GroupBy(p => new { p.Asource, p.Bsource, p.ARotation, p.BRotation })
@@ -915,19 +904,19 @@ namespace DeepNestLib
                         {
                             A = A,
                             B = B,
-                            ARotation = A.rotation,
-                            BRotation = B.rotation,
-                            Asource = A.source.Value,
-                            Bsource = B.source.Value
+                            ARotation = A.Rotation,
+                            BRotation = B.Rotation,
+                            Asource = A.Source.Value,
+                            Bsource = B.Source.Value
 
                         };
                         DbCacheKey doc = new DbCacheKey()
                         {
-                            A = A.source.Value,
-                            B = B.source.Value,
+                            A = A.Source.Value,
+                            B = B.Source.Value,
 
-                            ARotation = A.rotation,
-                            BRotation = B.rotation
+                            ARotation = A.Rotation,
+                            BRotation = B.Rotation
 
                         };
                         if (!Inpairs(key, pairs.ToArray()) && !window.db.Has(doc))
@@ -954,7 +943,7 @@ namespace DeepNestLib
         {
             for (int k = 0; k < parts.Count; k++)
             {
-                if (parts[k].source == source)
+                if (parts[k].Source == source)
                 {
                     return parts[k];
                 }
@@ -1131,7 +1120,7 @@ namespace DeepNestLib
                 }
             }
 
-            for (int i = 0; i < clipperNfp.length; i++)
+            for (int i = 0; i < clipperNfp.Length; i++)
             {
                 clipperNfp[i].x += B[0].x;
                 clipperNfp[i].y += B[0].y;
@@ -1159,8 +1148,8 @@ namespace DeepNestLib
         }
         public static NFP getHull(NFP polygon)
         {
-            double[][] points = new double[polygon.length][];
-            for (int i = 0; i < polygon.length; i++)
+            double[][] points = new double[polygon.Length][];
+            for (int i = 0; i < polygon.Length; i++)
             {
                 points[i] = (new double[] { polygon[i].x, polygon[i].y });
             }
@@ -1194,7 +1183,7 @@ namespace DeepNestLib
                 {
                     if (GeometryUtil.PolygonArea(nfp.children[j]) < 0)
                     {
-                        nfp.children[j].reverse();
+                        nfp.children[j].Reverse();
                     }
                     //var childNfp = SvgNest.toClipperCoordinates(nfp.children[j]);
                     IntPoint[] childNfp = ClipperHelper.ScaleUpPaths(nfp.children[j], config.ClipperScale);
@@ -1204,7 +1193,7 @@ namespace DeepNestLib
 
             if (GeometryUtil.PolygonArea(nfp) > 0)
             {
-                nfp.reverse();
+                nfp.Reverse();
             }
 
             // clipper js defines holes based on orientation
@@ -1237,10 +1226,10 @@ namespace DeepNestLib
 
             DbCacheKey key = new DbCacheKey()
             {
-                A = A.source,
-                B = B.source,
-                ARotation = A.rotation,
-                BRotation = B.rotation,
+                A = A.Source,
+                B = B.Source,
+                ARotation = A.Rotation,
+                BRotation = B.Rotation,
                 //Type = type
             };
 
@@ -1279,7 +1268,7 @@ namespace DeepNestLib
                     }
                 }
 
-                for (int i = 0; i < clipperNfp.length; i++)
+                for (int i = 0; i < clipperNfp.Length; i++)
                 {
                     clipperNfp[i].x += B[0].x;
                     clipperNfp[i].y += B[0].y;
@@ -1299,14 +1288,14 @@ namespace DeepNestLib
             {
                 return null;
             }
-            if (!inside && A.source != null && B.source != null)
+            if (!inside && A.Source != null && B.Source != null)
             {
                 DbCacheKey doc2 = new DbCacheKey()
                 {
-                    A = A.source.Value,
-                    B = B.source.Value,
-                    ARotation = A.rotation,
-                    BRotation = B.rotation,
+                    A = A.Source.Value,
+                    B = B.Source.Value,
+                    ARotation = A.Rotation,
+                    BRotation = B.Rotation,
                     nfp = nfp
                 };
                 window.db.Insert(doc2);

--- a/src/DeepNestLib/Rotation/RotationConstraint.cs
+++ b/src/DeepNestLib/Rotation/RotationConstraint.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace DeepNestLib.Rotation
+{
+    public enum RotationConstraint
+    {
+        Fixed,
+        Fixed180,
+        Ninety,
+        Free
+    }
+
+    public static class RotationHelpers
+    {
+        public static List<float> GetAllowedRotation(NFP part)
+        {
+            RotationConstraint constraint = part.RotationConstraint;
+
+            return constraint switch
+            {
+                RotationConstraint.Fixed => [0f],
+                RotationConstraint.Fixed180 => [0f, 180f],
+                RotationConstraint.Ninety => [0f, 90f],
+                _ => [0f, 90f, 180f, 270f]
+            };
+
+        }
+    }
+}

--- a/src/DeepNestLib/Simplify.cs
+++ b/src/DeepNestLib/Simplify.cs
@@ -62,7 +62,7 @@ namespace DeepNestLib
 
             SvgPoint point = null;
             int i = 1;
-            for (int len = points.length; i < len; i++)
+            for (int len = points.Length; i < len; i++)
             {
                 point = points[i];
 
@@ -105,7 +105,7 @@ namespace DeepNestLib
                     simplifyDPStep(points, first, index, sqTolerance, simplified);
                 }
 
-                simplified.push(points[index]);
+                simplified.Push(points[index]);
                 if (last - index > 1)
                 {
                     simplifyDPStep(points, index, last, sqTolerance, simplified);
@@ -116,12 +116,12 @@ namespace DeepNestLib
         // simplification using Ramer-Douglas-Peucker algorithm
         public static NFP simplifyDouglasPeucker(NFP points, double? sqTolerance)
         {
-            int last = points.length - 1;
+            int last = points.Length - 1;
 
             NFP simplified = new NFP();
             simplified.AddPoint(points[0]);
             simplifyDPStep(points, 0, last, sqTolerance, simplified);
-            simplified.push(points[last]);
+            simplified.Push(points[last]);
 
             return simplified;
         }
@@ -130,7 +130,7 @@ namespace DeepNestLib
         public static NFP simplify(NFP points, double? tolerance, bool highestQuality)
         {
 
-            if (points.length <= 2)
+            if (points.Length <= 2)
             {
                 return points;
             }

--- a/src/DeepNestLib/Svg/SvgNest.cs
+++ b/src/DeepNestLib/Svg/SvgNest.cs
@@ -33,7 +33,7 @@ namespace DeepNestLib.Svg
         {
             List<InrangeItem> inrange = new List<InrangeItem>();
             // find closest points within 2 offset deltas
-            for (int j = 0; j < simple.length; j++)
+            for (int j = 0; j < simple.Length; j++)
             {
                 SvgPoint s = simple[j];
                 double d2 = (o.x - s.x) * (o.x - s.x) + (o.y - s.y) * (o.y - s.y);
@@ -65,7 +65,7 @@ namespace DeepNestLib.Svg
             else
             {
                 double? mind = null;
-                for (int j = 0; j < simple.length; j++)
+                for (int j = 0; j < simple.Length; j++)
                 {
                     SvgPoint s = simple[j];
                     double d2 = (o.x - s.x) * (o.x - s.x) + (o.y - s.y) * (o.y - s.y);
@@ -83,7 +83,7 @@ namespace DeepNestLib.Svg
         public static NFP Clone(NFP p)
         {
             NFP newp = new NFP();
-            for (int i = 0; i < p.length; i++)
+            for (int i = 0; i < p.Length; i++)
             {
                 newp.AddPoint(new SvgPoint(
 
@@ -109,7 +109,7 @@ namespace DeepNestLib.Svg
         public static bool Exterior(NFP simple, NFP complex, bool inside)
         {
             // find all protruding vertices
-            for (int i = 0; i < complex.length; i++)
+            for (int i = 0; i < complex.Length; i++)
             {
                 SvgPoint v = complex[i];
                 if (!inside && !PointInPolygon(v, simple) && Find(v, simple) == null)
@@ -147,7 +147,7 @@ namespace DeepNestLib.Svg
             }
 
             NFP cleaned = CleanPolygon2(polygon);
-            if (cleaned != null && cleaned.length > 1)
+            if (cleaned != null && cleaned.Length > 1)
             {
                 polygon = cleaned;
             }
@@ -156,12 +156,12 @@ namespace DeepNestLib.Svg
                 return polygon;
             }
             // polygon to polyline
-            NFP copy = polygon.slice(0);
-            copy.push(copy[0]);
+            NFP copy = polygon.Slice(0);
+            copy.Push(copy[0]);
             // mark all segments greater than ~0.25 in to be kept
             // the PD simplification algo doesn't care about the accuracy of long lines, only the absolute distance of each point
             // we care a great deal
-            for (i = 0; i < copy.length - 1; i++)
+            for (i = 0; i < copy.Length - 1; i++)
             {
                 SvgPoint p1 = copy[i];
                 SvgPoint p2 = copy[i + 1];
@@ -208,16 +208,16 @@ namespace DeepNestLib.Svg
             }
 
             // mark any points that are exact
-            for (i = 0; i < simple.length; i++)
+            for (i = 0; i < simple.Length; i++)
             {
                 NFP seg = new NFP();
                 seg.AddPoint(simple[i]);
-                seg.AddPoint(simple[i + 1 == simple.length ? 0 : i + 1]);
+                seg.AddPoint(simple[i + 1 == simple.Length ? 0 : i + 1]);
 
                 int? index1 = Find(seg[0], polygon);
                 int? index2 = Find(seg[1], polygon);
 
-                if (index1 + 1 == index2 || index2 + 1 == index1 || index1 == 0 && index2 == polygon.length - 1 || index2 == 0 && index1 == polygon.length - 1)
+                if (index1 + 1 == index2 || index2 + 1 == index1 || index1 == 0 && index2 == polygon.Length - 1 || index2 == 0 && index1 == polygon.Length - 1)
                 {
                     seg[0].exact = true;
                     seg[1].exact = true;
@@ -242,7 +242,7 @@ namespace DeepNestLib.Svg
                 return polygon;
             }
             // selective reversal of offset
-            for (i = 0; i < offset.length; i++)
+            for (i = 0; i < offset.Length; i++)
             {
                 SvgPoint o = offset[i];
                 SvgPoint target = GetTarget(o, simple, 2 * tolerance);
@@ -279,10 +279,10 @@ namespace DeepNestLib.Svg
                 }
             }
 
-            for (i = 0; i < offset.length; i++)
+            for (i = 0; i < offset.Length; i++)
             {
                 SvgPoint p1 = offset[i];
-                SvgPoint p2 = offset[i + 1 == offset.length ? 0 : i + 1];
+                SvgPoint p2 = offset[i + 1 == offset.Length ? 0 : i + 1];
 
                 double sqd = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
 
@@ -290,10 +290,10 @@ namespace DeepNestLib.Svg
                 {
                     continue;
                 }
-                for (j = 0; j < simple.length; j++)
+                for (j = 0; j < simple.Length; j++)
                 {
                     SvgPoint s1 = simple[j];
-                    SvgPoint s2 = simple[j + 1 == simple.length ? 0 : j + 1];
+                    SvgPoint s2 = simple[j + 1 == simple.Length ? 0 : j + 1];
 
                     double sqds = (p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y);
 
@@ -342,15 +342,15 @@ namespace DeepNestLib.Svg
             }
 
             cleaned = CleanPolygon2(offset);
-            if (cleaned != null && cleaned.length > 1)
+            if (cleaned != null && cleaned.Length > 1)
             {
                 offset = cleaned;
             }
 
             // mark any points that are exact (for line merge detection)
-            for (i = 0; i < offset.length; i++)
+            for (i = 0; i < offset.Length; i++)
             {
-                SvgPoint[] seg = new SvgPoint[] { offset[i], offset[i + 1 == offset.length ? 0 : i + 1] };
+                SvgPoint[] seg = new SvgPoint[] { offset[i], offset[i + 1 == offset.Length ? 0 : i + 1] };
                 int? index1 = Find(seg[0], polygon);
                 int? index2 = Find(seg[1], polygon);
                 if (index1 == null)
@@ -362,8 +362,8 @@ namespace DeepNestLib.Svg
                     index2 = 0;
                 }
                 if (index1 + 1 == index2 || index2 + 1 == index1
-                    || index1 == 0 && index2 == polygon.length - 1 ||
-                    index2 == 0 && index1 == polygon.length - 1)
+                    || index1 == 0 && index2 == polygon.Length - 1 ||
+                    index2 == 0 && index1 == polygon.Length - 1)
                 {
                     seg[0].exact = true;
                     seg[1].exact = true;
@@ -380,7 +380,7 @@ namespace DeepNestLib.Svg
         }
         public static int? Find(SvgPoint v, NFP p)
         {
-            for (int i = 0; i < p.length; i++)
+            for (int i = 0; i < p.Length; i++)
             {
                 if (GeometryUtil.WithinDistance(v, p[i], Config.CurveTolerance / 1000))
                 {
@@ -409,7 +409,7 @@ namespace DeepNestLib.Svg
 
                 List<SvgPoint> rett = new List<SvgPoint>();
                 rett.AddRange(offsetpaths[0].Points);
-                rett.AddRange(t.Points.Skip(t.length));
+                rett.AddRange(t.Points.Skip(t.Length));
                 t.Points = rett.ToArray();
             }
 
@@ -558,7 +558,7 @@ namespace DeepNestLib.Svg
 
             // remove duplicate endpoints
             SvgPoint start = cleaned[0];
-            SvgPoint end = cleaned[cleaned.length - 1];
+            SvgPoint end = cleaned[cleaned.Length - 1];
             if (start == end || GeometryUtil.AlmostEqual(start.x, end.x)
                 && GeometryUtil.AlmostEqual(start.y, end.y))
             {
@@ -703,8 +703,8 @@ namespace DeepNestLib.Svg
                         for (int j = 0; j < parts[i].Quanity; j++)
                         {
                             NFP poly = CloneTree(parts[i].Polygon); // deep copy
-                            poly.id = id; // id is the unique id of all parts that will be nested, including cloned duplicates
-                            poly.source = i; // source is the id of each unique part from the main part list
+                            poly.Id = id; // id is the unique id of all parts that will be nested, including cloned duplicates
+                            poly.Source = i; // source is the id of each unique part from the main part list
 
                             adam.Add(poly);
                             id++;
@@ -751,8 +751,8 @@ namespace DeepNestLib.Svg
                     for (int j = 0; j < parts[i].Quanity; j++)
                     {
                         NFP cln = CloneTree(poly);
-                        cln.id = sid; // id is the unique id of all parts that will be nested, including cloned duplicates
-                        cln.source = poly.source; // source is the id of each unique part from the main part list
+                        cln.Id = sid; // id is the unique id of all parts that will be nested, including cloned duplicates
+                        cln.Source = poly.Source; // source is the id of each unique part from the main part list
 
                         sheets.Add(cln);
                         sheetids.Add(sid);
@@ -777,8 +777,8 @@ namespace DeepNestLib.Svg
 
                     for (int j = 0; j < ga.Population[i].placements.Count; j++)
                     {
-                        int id = ga.Population[i].placements[j].id;
-                        int? source = ga.Population[i].placements[j].source;
+                        int id = ga.Population[i].placements[j].Id;
+                        int? source = ga.Population[i].placements[j].Source;
                         List<NFP> child = ga.Population[i].placements[j].children;
                         ids.Add(id);
                         sources.Add(source.Value);
@@ -809,7 +809,7 @@ namespace DeepNestLib.Svg
         public static IntPoint[] ToClipperCoordinates(NFP polygon)
         {
             List<IntPoint> clone = new List<IntPoint>();
-            for (int i = 0; i < polygon.length; i++)
+            for (int i = 0; i < polygon.Length; i++)
             {
                 clone.Add
                     (new IntPoint(

--- a/src/DeepNestLib/Svg/SvgParser.cs
+++ b/src/DeepNestLib/Svg/SvgParser.cs
@@ -104,7 +104,7 @@ namespace DeepNestLib.Svg
                 }
                 Matrix m = new Matrix();
                 m.Translate((float)item.x, (float)item.y);
-                m.Rotate(item.rotation);
+                m.Rotate(item.Rotation);
 
                 PointF[] pp = item.Points.Select(z => new PointF((float)z.x, (float)z.y)).ToArray();
                 m.TransformPoints(pp);


### PR DESCRIPTION
### TL;DR

Refactored NFP class properties to use PascalCase naming convention and added rotation constraint functionality.

### What changed?

- Updated NFP class properties from camelCase to PascalCase (`id` → `Id`, `source` → `Source`, `rotation` → `Rotation`, `length` → `Length`)
- Changed method names to PascalCase (`push` → `Push`, `slice` → `Slice`, `reverse` → `Reverse`)
- Added new `RotationConstraint` enum with values: Fixed, Fixed180, Ninety, Free
- Added `RotationHelpers` class with `GetAllowedRotation` method to determine valid rotation angles based on constraints
- Updated placement logic to respect rotation constraints when trying to fit parts
- Bumped package version from 1.2.1 to 1.3.0

### How to test?

1. Create NFP objects and verify the new PascalCase properties work correctly
2. Test rotation constraints by setting different `RotationConstraint` values on parts
3. Run nesting operations to ensure parts respect their rotation constraints
4. Verify existing functionality still works with the renamed properties and methods

### Why make this change?

This change improves code consistency by following C# naming conventions (PascalCase for public properties and methods) and adds important functionality for controlling part rotation during nesting operations, which is essential for real-world manufacturing constraints.