### PR TITLE
feat(nesting): Add rotation constraint to cache.

### DIFF
--- a/src/DeepNestLib/Background/DbCache.cs
+++ b/src/DeepNestLib/Background/DbCache.cs
@@ -17,7 +17,7 @@ namespace DeepNestLib.Background
         internal void Insert(DbCacheKey obj, bool inner = false)
         {
             NfpCacheKey key = new NfpCacheKey(obj); // Create the new struct key
-            List<NFP> value = NestingService.CloneNfp(obj.nfp, inner).ToList();
+            List<NFP> value = NestingService.CloneNfp(obj.Nfp, inner).ToList();
             window.nfpCache.TryAdd(key, value);
         }
 

--- a/src/DeepNestLib/DbCacheKey.cs
+++ b/src/DeepNestLib/DbCacheKey.cs
@@ -1,12 +1,16 @@
-﻿namespace DeepNestLib
+﻿using DeepNestLib.Rotation;
+
+namespace DeepNestLib
 {
     public class DbCacheKey
     {
-        public int? A;
-        public int? B;
-        public float ARotation;
-        public float BRotation;
-        public NFP[] nfp;
-        public int Type;
+        public int? A { get; set; }
+        public int? B { get; set; }
+        public float ARotation { get; set; }
+        public float BRotation { get; set; }
+        public RotationConstraint ARotationConstraint { get; set; } = RotationConstraint.Fixed;
+        public RotationConstraint BRotationConstraint { get; set; } = RotationConstraint.Fixed;
+        public NFP[] Nfp { get; set; }
+        public int Type { get; set; } = 0;
     }
 }

--- a/src/DeepNestLib/NFP.cs
+++ b/src/DeepNestLib/NFP.cs
@@ -16,7 +16,7 @@ namespace DeepNestLib
         public double? offsety;
         public int Length => Points?.Length ?? 0;
         public int? Source { get; set; }
-        public int? Id { get; set; }
+        public int Id { get; set; }
         public float Rotation { get; set; } = 0f;
         public RotationConstraint RotationConstraint { get; set; } = RotationConstraint.Fixed;
         public SvgPoint[] Points;

--- a/src/DeepNestLib/NestingService.cs
+++ b/src/DeepNestLib/NestingService.cs
@@ -272,9 +272,10 @@ namespace DeepNestLib
                     B = B.Source.Value,
                     ARotation = 0,
                     BRotation = B.Rotation,
-                    //Inside =true??
+                    ARotationConstraint = A.RotationConstraint,
+                    BRotationConstraint = B.RotationConstraint
                 };
-                //var doc = window.db.find({ A: A.source, B: B.source, Arotation: 0, Brotation: B.rotation }, true);
+
                 NFP[] res = window.db.Find(key, true);
                 if (res != null)
                 {
@@ -342,7 +343,9 @@ namespace DeepNestLib
                     B = B.Source.Value,
                     ARotation = 0,
                     BRotation = B.Rotation,
-                    nfp = f.ToArray()
+                    ARotationConstraint = A.RotationConstraint,
+                    BRotationConstraint = B.RotationConstraint,
+                    Nfp = f.ToArray()
 
 
                 };
@@ -876,7 +879,9 @@ namespace DeepNestLib
                             A = A.Source.Value,
                             B = B.Source.Value,
                             ARotation = A.Rotation,
-                            BRotation = B.Rotation
+                            BRotation = B.Rotation,
+                            ARotationConstraint = A.RotationConstraint,
+                            BRotationConstraint = B.RotationConstraint,
                         };
 
                         if (!window.db.Has(doc))
@@ -916,8 +921,9 @@ namespace DeepNestLib
                             B = B.Source.Value,
 
                             ARotation = A.Rotation,
-                            BRotation = B.Rotation
-
+                            BRotation = B.Rotation,
+                            ARotationConstraint = A.RotationConstraint,
+                            BRotationConstraint = B.RotationConstraint
                         };
                         if (!Inpairs(key, pairs.ToArray()) && !window.db.Has(doc))
                         {
@@ -997,7 +1003,9 @@ namespace DeepNestLib
                 B = processed.Bsource,
                 ARotation = processed.ARotation,
                 BRotation = processed.BRotation,
-                nfp = new[] { processed.nfp }
+                ARotationConstraint = A.RotationConstraint,
+                BRotationConstraint = B.RotationConstraint,
+                Nfp = new[] { processed.nfp }
             };
 
             window.db.Insert(doc);
@@ -1230,6 +1238,8 @@ namespace DeepNestLib
                 B = B.Source,
                 ARotation = A.Rotation,
                 BRotation = B.Rotation,
+                ARotationConstraint = A.RotationConstraint,
+                BRotationConstraint = B.RotationConstraint
                 //Type = type
             };
 
@@ -1296,7 +1306,9 @@ namespace DeepNestLib
                     B = B.Source.Value,
                     ARotation = A.Rotation,
                     BRotation = B.Rotation,
-                    nfp = nfp
+                    ARotationConstraint = A.RotationConstraint,
+                    BRotationConstraint = B.RotationConstraint,
+                    Nfp = nfp
                 };
                 window.db.Insert(doc2);
 

--- a/src/DeepNestLib/NoFitPolygon/NfpCacheKey.cs
+++ b/src/DeepNestLib/NoFitPolygon/NfpCacheKey.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DeepNestLib.Rotation;
+using System;
 
 namespace DeepNestLib.NoFitPolygon
 {
@@ -6,6 +7,8 @@ namespace DeepNestLib.NoFitPolygon
     {
         public readonly int A, B, Type;
         public readonly int ARotation, BRotation; // Use scaled integers for rotation
+        public readonly RotationConstraint ARotationConstraint;
+        public readonly RotationConstraint BRotationConstraint;
 
         public NfpCacheKey(DbCacheKey obj)
         {
@@ -14,10 +17,18 @@ namespace DeepNestLib.NoFitPolygon
             Type = obj.Type;
             ARotation = (int)Math.Round(obj.ARotation * 10000);
             BRotation = (int)Math.Round(obj.BRotation * 10000);
+            ARotationConstraint = obj.ARotationConstraint;
+            BRotationConstraint = obj.BRotationConstraint;
         }
 
         public bool Equals(NfpCacheKey other) =>
-            A == other.A && B == other.B && ARotation == other.ARotation && BRotation == other.BRotation && Type == other.Type;
+            A == other.A &&
+            B == other.B &&
+            ARotation == other.ARotation &&
+            BRotation == other.BRotation &&
+            Type == other.Type &&
+            ARotationConstraint == other.ARotationConstraint &&
+            BRotationConstraint == other.BRotationConstraint;
 
         public override bool Equals(object obj) => obj is NfpCacheKey other && Equals(other);
 
@@ -30,6 +41,8 @@ namespace DeepNestLib.NoFitPolygon
                 hash = hash * 23 + B.GetHashCode();
                 hash = hash * 23 + ARotation.GetHashCode();
                 hash = hash * 23 + BRotation.GetHashCode();
+                hash = hash * 23 + ARotationConstraint.GetHashCode();
+                hash = hash * 23 + BRotationConstraint.GetHashCode();
                 hash = hash * 23 + Type.GetHashCode();
                 return hash;
             }


### PR DESCRIPTION
### TL;DR

Added rotation constraint tracking to the NFP caching system and converted DbCacheKey fields to properties with default values.

### What changed?

- Added `ARotationConstraint` and `BRotationConstraint` fields to `DbCacheKey` and `NfpCacheKey` classes
- Converted all `DbCacheKey` fields to properties with appropriate default values (`RotationConstraint.Fixed` for constraints, `0` for Type)
- Changed `NFP.Id` from nullable int to non-nullable int
- Updated property name from `nfp` to `Nfp` in `DbCacheKey` for consistency
- Modified cache key equality and hash code calculations to include rotation constraints
- Updated all NFP generation and caching operations throughout `NestingService` to populate rotation constraint fields

### How to test?

- Verify that NFP caching still works correctly with different rotation constraints
- Test that cache hits and misses behave properly when rotation constraints differ
- Ensure that existing cached NFPs are handled correctly with the new constraint fields
- Validate that the property changes don't break serialization or other dependent code

### Why make this change?

This change enables the caching system to differentiate between NFPs based on rotation constraints, preventing incorrect cache hits when shapes have different rotation behaviors. The property conversion improves code consistency and provides sensible defaults for new instances.